### PR TITLE
Feature: 방해금지 모드, 소리 on/off 기능 연결 / ui 수정

### DIFF
--- a/src/pages/home/apis/patchModeSoundActive.ts
+++ b/src/pages/home/apis/patchModeSoundActive.ts
@@ -1,0 +1,18 @@
+import type {
+  UpdateModeSoundActiveRequestTypes,
+  UpdateModeSoundActiveResponseTypes,
+} from '@/pages/home/types/modeTypes';
+import http from '@/shared/apis/axios';
+// 모드에 담긴 소리 on off API
+export const patchModeSoundActive = async (
+  modeId: number,
+  soundId: number,
+  soundActiveData: UpdateModeSoundActiveRequestTypes,
+): Promise<UpdateModeSoundActiveResponseTypes> => {
+  const response = await http.patch<UpdateModeSoundActiveResponseTypes>(
+    `/api/v1/modes/${modeId}/sounds/${soundId}`,
+    soundActiveData,
+  );
+
+  return response.data;
+};

--- a/src/pages/home/components/HomeHeader.tsx
+++ b/src/pages/home/components/HomeHeader.tsx
@@ -1,23 +1,11 @@
-import { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell } from '@fortawesome/free-solid-svg-icons';
-import SilentModeButton from '@/pages/home/components/mode/SilentModeButton';
-import { usePatchDoNotDisturb } from '@/shared/hooks/usePatchDoNotDisturb';
+import DoNotDisturbButton from '@/pages/home/components/mode/DoNotDisturbButton';
+import { useHomeModeContext } from '@/pages/home/hooks/useHomeModeContext';
 
 const HomeHeader = () => {
-  const { mutate: updateDoNotDisturb, isPending } = usePatchDoNotDisturb();
-  const [isDoNotDisturb, setIsDoNotDisturb] = useState(false);
-
-  const handleSilentToggle = () => {
-    const nextIsDoNotDisturb = !isDoNotDisturb;
-
-    setIsDoNotDisturb(nextIsDoNotDisturb);
-    updateDoNotDisturb(nextIsDoNotDisturb, {
-      onError: () => {
-        setIsDoNotDisturb(isDoNotDisturb);
-      },
-    });
-  };
+  const { isDoNotDisturb, isDoNotDisturbPending, handleDoNotDisturbToggle } =
+    useHomeModeContext();
 
   return (
     <header className="mt-[2.75rem] mb-[2.5rem] flex flex-col gap-[1.5rem]">
@@ -39,10 +27,10 @@ const HomeHeader = () => {
           <br />
           환경에 맞는 모드를 선택하세요
         </p>
-        <SilentModeButton
-          isSilent={isDoNotDisturb}
-          isDisabled={isPending}
-          onToggle={handleSilentToggle}
+        <DoNotDisturbButton
+          isDoNotDisturb={isDoNotDisturb}
+          isDisabled={isDoNotDisturbPending}
+          onToggle={handleDoNotDisturbToggle}
         />
       </div>
     </header>

--- a/src/pages/home/components/HomeHeader.tsx
+++ b/src/pages/home/components/HomeHeader.tsx
@@ -2,13 +2,21 @@ import { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell } from '@fortawesome/free-solid-svg-icons';
 import SilentModeButton from '@/pages/home/components/mode/SilentModeButton';
+import { usePatchDoNotDisturb } from '@/shared/hooks/usePatchDoNotDisturb';
 
 const HomeHeader = () => {
-  // 방해금지 모드 토글 (UI 상태만 — 실제 동작은 추후 연동)
-  const [isSilent, setIsSilent] = useState(false);
+  const { mutate: updateDoNotDisturb, isPending } = usePatchDoNotDisturb();
+  const [isDoNotDisturb, setIsDoNotDisturb] = useState(false);
 
   const handleSilentToggle = () => {
-    setIsSilent((prev) => !prev);
+    const nextIsDoNotDisturb = !isDoNotDisturb;
+
+    setIsDoNotDisturb(nextIsDoNotDisturb);
+    updateDoNotDisturb(nextIsDoNotDisturb, {
+      onError: () => {
+        setIsDoNotDisturb(isDoNotDisturb);
+      },
+    });
   };
 
   return (
@@ -31,7 +39,11 @@ const HomeHeader = () => {
           <br />
           환경에 맞는 모드를 선택하세요
         </p>
-        <SilentModeButton isSilent={isSilent} onToggle={handleSilentToggle} />
+        <SilentModeButton
+          isSilent={isDoNotDisturb}
+          isDisabled={isPending}
+          onToggle={handleSilentToggle}
+        />
       </div>
     </header>
   );

--- a/src/pages/home/components/mode/DoNotDisturbButton.tsx
+++ b/src/pages/home/components/mode/DoNotDisturbButton.tsx
@@ -1,21 +1,21 @@
-import SilentModeIcon from '@/shared/components/icons/SilentModeIcon';
+import DoNotDisturbIcon from '@/shared/components/icons/DoNotDisturbIcon';
 
-interface SilentModeButtonPropTypes {
-  isSilent: boolean;
+interface DoNotDisturbButtonPropTypes {
+  isDoNotDisturb: boolean;
   isDisabled?: boolean;
   onToggle: () => void;
 }
 
-const SilentModeButton = ({
-  isSilent,
+const DoNotDisturbButton = ({
+  isDoNotDisturb,
   isDisabled = false,
   onToggle,
-}: SilentModeButtonPropTypes) => {
+}: DoNotDisturbButtonPropTypes) => {
   return (
     <button
       type="button"
       role="switch"
-      aria-checked={isSilent}
+      aria-checked={isDoNotDisturb}
       aria-label="방해금지 모드"
       disabled={isDisabled}
       onClick={onToggle}
@@ -24,23 +24,23 @@ const SilentModeButton = ({
       {/* 텍스트: thumb 반대편에 고정 */}
       <span
         className={`caption-xs-regular absolute top-1/2 -translate-y-1/2 text-primary transition-all ${
-          isSilent ? 'left-[0.875rem]' : 'right-[0.875rem]'
+          isDoNotDisturb ? 'left-[0.875rem]' : 'right-[0.875rem]'
         }`}
       >
-        방해금지 모드 {isSilent ? 'on' : 'off'}
+        방해금지 모드 {isDoNotDisturb ? 'on' : 'off'}
       </span>
 
       {/* thumb 역할의 달 아이콘 원: off=왼쪽, on=오른쪽으로 미끄러짐 */}
       <span
         className={`absolute top-[0.375rem] left-[0.375rem] flex h-[1.75rem] w-[1.75rem] items-center justify-center rounded-pill transition-all duration-300 ease-in-out ${
-          isSilent
+          isDoNotDisturb
             ? 'translate-x-[5.5rem] bg-primary-500 shadow-light-20'
             : 'translate-x-0 bg-tertiary'
         }`}
       >
-        <SilentModeIcon
+        <DoNotDisturbIcon
           className={`h-[1rem] w-[1rem] ${
-            isSilent ? 'text-primary' : 'text-disabled'
+            isDoNotDisturb ? 'text-primary' : 'text-disabled'
           }`}
         />
       </span>
@@ -48,4 +48,4 @@ const SilentModeButton = ({
   );
 };
 
-export default SilentModeButton;
+export default DoNotDisturbButton;

--- a/src/pages/home/components/mode/ModeCard.tsx
+++ b/src/pages/home/components/mode/ModeCard.tsx
@@ -15,7 +15,11 @@ const ModeCard = ({
   isSelected,
   isDoNotDisturb,
 }: ModeCardPropTypes) => {
-  const { handleActivateModeClick, handleMoveModeSettingClick } = useModeCard({
+  const {
+    handleActivateModeClick,
+    handleActivateModeKeyDown,
+    handleMoveModeSettingClick,
+  } = useModeCard({
     modeId: mode.mode_id,
     isDoNotDisturb,
   });
@@ -35,7 +39,10 @@ const ModeCard = ({
   return (
     // 화살표 제외 영역은 누르면 활성 비활성
     <div
+      role="button"
+      tabIndex={isDoNotDisturb ? -1 : 0}
       onClick={handleActivateModeClick}
+      onKeyDown={handleActivateModeKeyDown}
       aria-disabled={isDoNotDisturb}
       className={`relative flex h-full w-full flex-col justify-between overflow-hidden rounded-xl p-sm tag-glass-effect card-false transition-colors duration-300 ease-in-out ${modeCardStyle}`}
     >

--- a/src/pages/home/components/mode/ModeCard.tsx
+++ b/src/pages/home/components/mode/ModeCard.tsx
@@ -7,29 +7,46 @@ import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
 interface ModeCardPropTypes {
   mode: ModeTypes;
   isSelected: boolean;
+  isDoNotDisturb: boolean;
 }
 
-const ModeCard = ({ mode, isSelected }: ModeCardPropTypes) => {
+const ModeCard = ({
+  mode,
+  isSelected,
+  isDoNotDisturb,
+}: ModeCardPropTypes) => {
   const { handleActivateModeClick, handleMoveModeSettingClick } = useModeCard({
     modeId: mode.mode_id,
+    isDoNotDisturb,
   });
+
+  const modeCardStyle = isDoNotDisturb
+    ? 'cursor-not-allowed text-disabled opacity-60'
+    : isSelected
+      ? 'cursor-pointer text-primary'
+      : 'cursor-pointer text-tertiary';
+
+  const modeIconStyle = isDoNotDisturb
+    ? 'bg-neutral-700 text-disabled'
+    : isSelected
+      ? 'text-white bg-primary-500/20 text-primary-500'
+      : 'bg-neutral-700 text-tertiary';
 
   return (
     // 화살표 제외 영역은 누르면 활성 비활성
     <div
       onClick={handleActivateModeClick}
-      className={`relative flex h-full w-full cursor-pointer flex-col justify-between overflow-hidden rounded-xl p-sm tag-glass-effect card-false transition-colors duration-300 ease-in-out ${
-        isSelected ? 'text-primary' : 'text-tertiary'
-      }`}
+      aria-disabled={isDoNotDisturb}
+      className={`relative flex h-full w-full flex-col justify-between overflow-hidden rounded-xl p-sm tag-glass-effect card-false transition-colors duration-300 ease-in-out ${modeCardStyle}`}
     >
       <span
         aria-hidden
         className={`pointer-events-none absolute inset-0 card-true transition-opacity duration-300 ease-in-out ${
-          isSelected ? 'opacity-100' : 'opacity-0'
+          isSelected && !isDoNotDisturb ? 'opacity-100' : 'opacity-0'
         }`}
       />
       <span
-        className={`relative z-10 flex items-center justify-center w-[3rem] h-[3rem]  rounded-full p-2 transition-colors duration-300 ease-in-out ${isSelected ? 'text-white bg-primary-500/20 text-primary-500' : 'bg-neutral-700 text-tertiary'}`}
+        className={`relative z-10 flex items-center justify-center w-[3rem] h-[3rem]  rounded-full p-2 transition-colors duration-300 ease-in-out ${modeIconStyle}`}
       >
         {mode.icon}
       </span>

--- a/src/pages/home/components/mode/ModeList.tsx
+++ b/src/pages/home/components/mode/ModeList.tsx
@@ -3,7 +3,8 @@ import ModeCard from '@/pages/home/components/mode/ModeCard';
 import { useModeList } from '@/pages/home/hooks/useModeList';
 
 const ModeList = () => {
-  const { modes, selectedModeId, isLoading, isError } = useModeList();
+  const { modes, selectedModeId, isDoNotDisturb, isLoading, isError } =
+    useModeList();
 
   if (isLoading) {
     return <div>불러오는 중...</div>;
@@ -21,6 +22,7 @@ const ModeList = () => {
             key={mode.mode_id}
             mode={mode}
             isSelected={mode.mode_id === selectedModeId}
+            isDoNotDisturb={isDoNotDisturb}
           />
         ))}
       </div>

--- a/src/pages/home/components/mode/SilentModeButton.tsx
+++ b/src/pages/home/components/mode/SilentModeButton.tsx
@@ -2,11 +2,13 @@ import SilentModeIcon from '@/shared/components/icons/SilentModeIcon';
 
 interface SilentModeButtonPropTypes {
   isSilent: boolean;
+  isDisabled?: boolean;
   onToggle: () => void;
 }
 
 const SilentModeButton = ({
   isSilent,
+  isDisabled = false,
   onToggle,
 }: SilentModeButtonPropTypes) => {
   return (
@@ -15,8 +17,9 @@ const SilentModeButton = ({
       role="switch"
       aria-checked={isSilent}
       aria-label="방해금지 모드"
+      disabled={isDisabled}
       onClick={onToggle}
-      className="p-xxs relative h-[2.75rem] w-[8rem] border-[0.5px] border-neutral-500 rounded-pill bg-black"
+      className="p-xxs relative h-[2.75rem] w-[8rem] border-[0.5px] border-neutral-500 rounded-pill bg-black disabled:cursor-not-allowed disabled:opacity-60"
     >
       {/* 텍스트: thumb 반대편에 고정 */}
       <span

--- a/src/pages/home/components/modeForm/ModeForm.tsx
+++ b/src/pages/home/components/modeForm/ModeForm.tsx
@@ -44,7 +44,7 @@ const ModeFormContent = () => {
   } = useModeFormContext();
 
   return (
-    <div className="min-h-dvh px-[1.03rem]">
+    <div className="min-h-dvh px-[1.03rem] ">
       <ModeHeader
         title={headerTitle}
         actionLabel={headerActionLabel}

--- a/src/pages/home/components/modeForm/ModeSoundSelectBlock.tsx
+++ b/src/pages/home/components/modeForm/ModeSoundSelectBlock.tsx
@@ -1,3 +1,10 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faMinus,
+  faPlus,
+  faVolumeHigh,
+} from '@fortawesome/free-solid-svg-icons';
+import CategoryBlock from '@/pages/home/components/sound/CategoryBlock';
 import type { SoundTypes } from '@/pages/home/types/soundTypes';
 
 interface ModeSoundSelectBlockPropTypes {
@@ -20,11 +27,35 @@ const ModeSoundSelectBlock = ({
       type="button"
       onClick={handleSoundToggleClick}
       aria-pressed={isSelected}
-      className={`p-2`}
+      className={`flex h-[4rem] w-full items-center gap-sm rounded-lg border px-base text-left transition-colors active:scale-[0.99] ${
+        isSelected
+          ? 'border-primary-300/70 bg-primary-300/10'
+          : 'border-neutral-700 bg-neutral-950/20'
+      }`}
     >
-      <p>{sound.name}</p>
-      <p>{sound.category_name}</p>
-      <p>{isSelected ? '선택됨' : '선택 안 됨'}</p>
+      <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-neutral-800 text-secondary">
+        <FontAwesomeIcon icon={faVolumeHigh} />
+      </span>
+
+      <span className="min-w-0 flex-1">
+        <span className="block truncate heading-lg-semibold text-primary">
+          {sound.name}
+        </span>
+      </span>
+
+      <span className="shrink-0">
+        <CategoryBlock categoryName={sound.category_name} />
+      </span>
+
+      <span
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-pill text-base ${
+          isSelected
+            ? 'bg-primary-300 text-inverse'
+            : 'bg-neutral-600 text-primary'
+        }`}
+      >
+        <FontAwesomeIcon icon={isSelected ? faMinus : faPlus} />
+      </span>
     </button>
   );
 };

--- a/src/pages/home/components/modeForm/ModeSoundSelectSection.tsx
+++ b/src/pages/home/components/modeForm/ModeSoundSelectSection.tsx
@@ -1,30 +1,109 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faChevronDown,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
+import SearchBar from '@/pages/home/components/SearchBar';
 import ModeSoundSelectBlock from '@/pages/home/components/modeForm/ModeSoundSelectBlock';
 import { useModeFormContext } from '@/pages/home/components/modeForm/ModeFormContext';
-import { useGetSounds } from '@/pages/home/hooks/useGetSounds';
+import { useModeSoundSelectSection } from '@/pages/home/hooks/useModeSoundSelectSection';
 
 const ModeSoundSelectSection = () => {
-  const { data, isLoading, isError } = useGetSounds();
   const { selectedSoundIds, handleSoundToggle } = useModeFormContext();
-
-  const sounds = data?.sounds ?? [];
+  const {
+    categorySoundGroups,
+    hasNoSearchResult,
+    isError,
+    isLoading,
+    isSearching,
+    openedCategoryId,
+    searchKeyword,
+    handleCategoryToggleClick,
+    handleSearchKeywordChange,
+  } = useModeSoundSelectSection();
 
   return (
-    <section aria-labelledby="sound-select-heading">
-      <h2 id="sound-select-heading">소리 선택</h2>
-
-      {isLoading && <p>소리 목록을 불러오는 중...</p>}
-      {isError && <p>소리 목록을 불러오지 못했습니다</p>}
-
-      <div>
-        {sounds.map((sound) => (
-          <ModeSoundSelectBlock
-            key={sound.sound_id}
-            sound={sound}
-            isSelected={selectedSoundIds.includes(sound.sound_id)}
-            onToggle={handleSoundToggle}
-          />
-        ))}
+    <section
+      aria-labelledby="sound-select-heading"
+      className="space-y-base mb-[3rem]"
+    >
+      <div className="flex items-center justify-between gap-base mb-lg">
+        <h2 id="sound-select-heading" className="heading-base-semibold">
+          소리 선택
+        </h2>
+        <span className="body-base-regular shrink-0 text-primary-500">
+          {selectedSoundIds.length}개 선택됨
+        </span>
       </div>
+
+      <SearchBar
+        value={searchKeyword}
+        placeholder="원하는 소리를 검색해보세요"
+        onChange={handleSearchKeywordChange}
+      />
+
+      {isLoading && (
+        <p className="body-sm-regular text-tertiary">
+          소리 목록을 불러오는 중...
+        </p>
+      )}
+      {isError && (
+        <p className="body-sm-regular text-state-alert">
+          소리 목록을 불러오지 못했습니다
+        </p>
+      )}
+      {hasNoSearchResult && (
+        <p className="body-sm-regular text-tertiary">검색 결과가 없습니다</p>
+      )}
+
+      {!isLoading && !isError && !hasNoSearchResult && (
+        <div className="space-y-sm">
+          {categorySoundGroups.map(({ category, sounds }) => {
+            const isOpened =
+              isSearching || openedCategoryId === category.category_id;
+
+            return (
+              <div key={category.category_id}>
+                <button
+                  type="button"
+                  aria-expanded={isOpened}
+                  onClick={() =>
+                    handleCategoryToggleClick(category.category_id)
+                  }
+                  className="flex h-[2.25rem] w-full items-center justify-between rounded-pill bg-neutral-800 px-base text-left transition-colors active:bg-neutral-700"
+                >
+                  <span className="min-w-0 truncate body-sm-regular text-primary">
+                    {category.name}
+                  </span>
+                  <FontAwesomeIcon
+                    icon={isOpened ? faChevronDown : faChevronRight}
+                    className="ml-sm h-icon-sm text-secondary"
+                  />
+                </button>
+
+                {isOpened && (
+                  <div className="mt-xs space-y-xs">
+                    {sounds.length > 0 ? (
+                      sounds.map((sound) => (
+                        <ModeSoundSelectBlock
+                          key={sound.sound_id}
+                          sound={sound}
+                          isSelected={selectedSoundIds.includes(sound.sound_id)}
+                          onToggle={handleSoundToggle}
+                        />
+                      ))
+                    ) : (
+                      <p className="px-base py-xs body-sm-regular text-tertiary">
+                        선택할 수 있는 소리가 없습니다
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
     </section>
   );
 };

--- a/src/pages/home/components/sound/SoundCard.tsx
+++ b/src/pages/home/components/sound/SoundCard.tsx
@@ -10,6 +10,7 @@ interface SoundCardSoundTypes {
 interface SoundCardPropTypes {
   sound: SoundCardSoundTypes;
   isDisabled?: boolean;
+  isDoNotDisturb?: boolean;
   isSelected?: boolean;
   isEditMode?: boolean;
   onClick?: (soundId: number) => void;
@@ -30,6 +31,7 @@ const getSoundIcon = (categoryName: string) => {
 const SoundCard = ({
   sound,
   isDisabled = false,
+  isDoNotDisturb = false,
   isSelected = false,
   isEditMode = false,
   onClick,
@@ -49,8 +51,11 @@ const SoundCard = ({
   return (
     <button
       type="button"
+      aria-disabled={isDoNotDisturb}
       onClick={handleSoundCardClick}
-      className={`aspect-square rounded-3xl border-2 p-3 text-center ${cardStyle} ${
+      className={`aspect-square rounded-3xl border-2 p-3 text-center ${
+        isDoNotDisturb ? 'cursor-not-allowed' : 'cursor-pointer'
+      } ${cardStyle} ${
         isSelected ? 'border-black' : 'border-transparent'
       }`}
     >

--- a/src/pages/home/components/sound/SoundCard.tsx
+++ b/src/pages/home/components/sound/SoundCard.tsx
@@ -9,10 +9,10 @@ interface SoundCardSoundTypes {
 
 interface SoundCardPropTypes {
   sound: SoundCardSoundTypes;
-  isDisabled?: boolean;
+  isActive?: boolean;
   isDoNotDisturb?: boolean;
-  isSelected?: boolean;
   isEditMode?: boolean;
+  isSelected?: boolean;
   onClick?: (soundId: number) => void;
 }
 
@@ -30,10 +30,10 @@ const getSoundIcon = (categoryName: string) => {
 
 const SoundCard = ({
   sound,
-  isDisabled = false,
+  isActive = true,
   isDoNotDisturb = false,
-  isSelected = false,
   isEditMode = false,
+  isSelected = false,
   onClick,
 }: SoundCardPropTypes) => {
   const categoryName = sound.category ?? sound.category_name ?? '기타';
@@ -42,28 +42,32 @@ const SoundCard = ({
     onClick?.(sound.sound_id);
   };
 
-  const cardStyle = isEditMode
-    ? 'bg-gray-300'
-    : isDisabled
-      ? 'bg-gray-300 opacity-70'
-      : 'bg-[#f8c3a4]';
+  const isOnStyle = isEditMode ? isSelected : isActive;
+
+  const cardStyle = isDoNotDisturb
+    ? 'bg-neutral-900 text-neutral-700'
+    : isOnStyle
+      ? 'card-true-bottomsheet tag-glass-effect text-primary'
+      : 'bg-neutral-800 text-primary border-[1px] solid border-neutral-600';
 
   return (
     <button
       type="button"
       aria-disabled={isDoNotDisturb}
       onClick={handleSoundCardClick}
-      className={`aspect-square rounded-3xl border-2 p-3 text-center ${
-        isDoNotDisturb ? 'cursor-not-allowed' : 'cursor-pointer'
-      } ${cardStyle} ${
-        isSelected ? 'border-black' : 'border-transparent'
-      }`}
+      className={`aspect-square rounded-xl p-sm text-center transition-all duration-500 ease-out ${
+        isDoNotDisturb
+          ? 'cursor-not-allowed'
+          : 'cursor-pointer active:scale-[0.97]'
+      } ${cardStyle} `}
     >
-      <div className="flex h-full flex-col items-center justify-center gap-3">
-        <span className="text-4xl font-black leading-none">
+      <div className="flex h-full flex-col items-center justify-center gap-xs transition-colors duration-300 ease-out">
+        <span className="w-icon-2xl h-icon-2xl font-black leading-none transition-transform duration-300 ease-out">
           {getSoundIcon(categoryName)}
         </span>
-        <span className="text-base font-bold">{sound.name}</span>
+        <span className="heading-base-semibold transition-colors duration-300 ease-out">
+          {sound.name}
+        </span>
         <CategoryBlock categoryName={categoryName} />
       </div>
     </button>

--- a/src/pages/home/components/sound/SoundSection.tsx
+++ b/src/pages/home/components/sound/SoundSection.tsx
@@ -13,7 +13,6 @@ const SoundSection = () => {
     isEditMode,
     isAddSoundModalOpen,
     selectedRemoveSoundIds,
-    disabledSoundIds,
     toggleEditMode,
     closeEditMode,
     openAddSoundModal,
@@ -32,18 +31,18 @@ const SoundSection = () => {
       <div className="mb-5 flex items-center justify-between">
         <h2 className="text-xl font-bold">담은 소리</h2>
         {isEditMode ? (
-          <div className="flex gap-3">
+          <div className="flex gap-base">
             <button
               type="button"
               onClick={closeEditMode}
-              className="text-sm font-bold text-neutral-500"
+              className="body-base-regular text-secondary"
             >
               취소
             </button>
             <button
               type="button"
               onClick={handleRemoveSelectedSoundsClick}
-              className="text-sm font-bold text-neutral-900 disabled:text-neutral-300"
+              className="body-base-regular text-state-alert"
               disabled={isDoNotDisturb || selectedRemoveSoundIds.length === 0}
             >
               삭제
@@ -53,7 +52,7 @@ const SoundSection = () => {
           <button
             type="button"
             onClick={toggleEditMode}
-            className="text-sm font-bold text-neutral-400 disabled:text-neutral-600"
+            className="body-base-regular text-tertiary"
             disabled={isDoNotDisturb}
           >
             편집
@@ -69,14 +68,11 @@ const SoundSection = () => {
           <SoundCard
             key={sound.sound_id}
             sound={sound}
-            isEditMode={isEditMode}
-            isDisabled={
-              isDoNotDisturb || disabledSoundIds.includes(sound.sound_id)
-            }
+            isActive={sound.is_active}
             isDoNotDisturb={isDoNotDisturb}
+            isEditMode={isEditMode}
             isSelected={
-              !isDoNotDisturb &&
-              selectedRemoveSoundIds.includes(sound.sound_id)
+              !isDoNotDisturb && selectedRemoveSoundIds.includes(sound.sound_id)
             }
             onClick={handleSoundCardClick}
           />

--- a/src/pages/home/components/sound/SoundSection.tsx
+++ b/src/pages/home/components/sound/SoundSection.tsx
@@ -6,6 +6,7 @@ import { useSoundSection } from '@/pages/home/hooks/useSoundSection';
 const SoundSection = () => {
   const {
     selectedModeId,
+    isDoNotDisturb,
     sounds,
     isLoading,
     isError,
@@ -43,7 +44,7 @@ const SoundSection = () => {
               type="button"
               onClick={handleRemoveSelectedSoundsClick}
               className="text-sm font-bold text-neutral-900 disabled:text-neutral-300"
-              disabled={selectedRemoveSoundIds.length === 0}
+              disabled={isDoNotDisturb || selectedRemoveSoundIds.length === 0}
             >
               삭제
             </button>
@@ -52,7 +53,8 @@ const SoundSection = () => {
           <button
             type="button"
             onClick={toggleEditMode}
-            className="text-sm font-bold text-neutral-400"
+            className="text-sm font-bold text-neutral-400 disabled:text-neutral-600"
+            disabled={isDoNotDisturb}
           >
             편집
           </button>
@@ -68,15 +70,28 @@ const SoundSection = () => {
             key={sound.sound_id}
             sound={sound}
             isEditMode={isEditMode}
-            isDisabled={disabledSoundIds.includes(sound.sound_id)}
-            isSelected={selectedRemoveSoundIds.includes(sound.sound_id)}
+            isDisabled={
+              isDoNotDisturb || disabledSoundIds.includes(sound.sound_id)
+            }
+            isDoNotDisturb={isDoNotDisturb}
+            isSelected={
+              !isDoNotDisturb &&
+              selectedRemoveSoundIds.includes(sound.sound_id)
+            }
             onClick={handleSoundCardClick}
           />
         ))}
       </div>
 
       <div className="mt-5 flex justify-center">
-        <AddBtn label="소리 추가하기" onClick={openAddSoundModal} />
+        <AddBtn
+          label="소리 추가하기"
+          onClick={openAddSoundModal}
+          disabled={isDoNotDisturb}
+          className={
+            isDoNotDisturb ? 'cursor-not-allowed opacity-60' : undefined
+          }
+        />
       </div>
 
       {isAddSoundModalOpen && (

--- a/src/pages/home/hooks/useHomeModeContext.tsx
+++ b/src/pages/home/hooks/useHomeModeContext.tsx
@@ -31,20 +31,23 @@ export const HomeModeProvider = ({ children }: HomeModeProviderPropTypes) => {
 
   // 모드 선택 함수 - 선택된 모드는 모드 목록과 소리 섹션이 함께 사용한다
   const handleModeSelect = useCallback((modeId: number) => {
-    console.log(`${modeId}로 바뀜`);
     setSelectedModeId(modeId);
   }, []);
 
   const handleDoNotDisturbToggle = useCallback(() => {
-    const nextIsDoNotDisturb = !isDoNotDisturb;
+    setIsDoNotDisturb((prevIsDoNotDisturb) => {
+      const nextIsDoNotDisturb = !prevIsDoNotDisturb;
 
-    setIsDoNotDisturb(nextIsDoNotDisturb);
-    updateDoNotDisturb(nextIsDoNotDisturb, {
-      onError: () => {
-        setIsDoNotDisturb(isDoNotDisturb);
-      },
+      // 화면은 즉시 토글하고, 서버 반영에 실패하면 이전 상태로 되돌린다.
+      updateDoNotDisturb(nextIsDoNotDisturb, {
+        onError: () => {
+          setIsDoNotDisturb(prevIsDoNotDisturb);
+        },
+      });
+
+      return nextIsDoNotDisturb;
     });
-  }, [isDoNotDisturb, updateDoNotDisturb]);
+  }, [updateDoNotDisturb]);
 
   const contextValue = useMemo(
     () => ({

--- a/src/pages/home/hooks/useHomeModeContext.tsx
+++ b/src/pages/home/hooks/useHomeModeContext.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from 'react';
 import type { ReactNode } from 'react';
+import { usePatchDoNotDisturb } from '@/shared/hooks/usePatchDoNotDisturb';
 
 interface HomeModeProviderPropTypes {
   children: ReactNode;
@@ -13,7 +14,10 @@ interface HomeModeProviderPropTypes {
 
 interface HomeModeContextTypes {
   selectedModeId: number | null;
+  isDoNotDisturb: boolean;
+  isDoNotDisturbPending: boolean;
   handleModeSelect: (modeId: number) => void;
+  handleDoNotDisturbToggle: () => void;
 }
 
 const HomeModeContext = createContext<HomeModeContextTypes | null>(null);
@@ -21,6 +25,9 @@ const HomeModeContext = createContext<HomeModeContextTypes | null>(null);
 // 현재 선택된 모드 ID를 모드 목록과 소리 섹션이 함께 공유하도록 보관하는 Provider
 export const HomeModeProvider = ({ children }: HomeModeProviderPropTypes) => {
   const [selectedModeId, setSelectedModeId] = useState<number | null>(null);
+  const [isDoNotDisturb, setIsDoNotDisturb] = useState(false);
+  const { mutate: updateDoNotDisturb, isPending: isDoNotDisturbPending } =
+    usePatchDoNotDisturb();
 
   // 모드 선택 함수 - 선택된 모드는 모드 목록과 소리 섹션이 함께 사용한다
   const handleModeSelect = useCallback((modeId: number) => {
@@ -28,12 +35,32 @@ export const HomeModeProvider = ({ children }: HomeModeProviderPropTypes) => {
     setSelectedModeId(modeId);
   }, []);
 
+  const handleDoNotDisturbToggle = useCallback(() => {
+    const nextIsDoNotDisturb = !isDoNotDisturb;
+
+    setIsDoNotDisturb(nextIsDoNotDisturb);
+    updateDoNotDisturb(nextIsDoNotDisturb, {
+      onError: () => {
+        setIsDoNotDisturb(isDoNotDisturb);
+      },
+    });
+  }, [isDoNotDisturb, updateDoNotDisturb]);
+
   const contextValue = useMemo(
     () => ({
       selectedModeId,
+      isDoNotDisturb,
+      isDoNotDisturbPending,
       handleModeSelect,
+      handleDoNotDisturbToggle,
     }),
-    [handleModeSelect, selectedModeId],
+    [
+      handleDoNotDisturbToggle,
+      handleModeSelect,
+      isDoNotDisturb,
+      isDoNotDisturbPending,
+      selectedModeId,
+    ],
   );
 
   return (

--- a/src/pages/home/hooks/useModeCard.ts
+++ b/src/pages/home/hooks/useModeCard.ts
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react';
+import type { KeyboardEvent, MouseEvent } from 'react';
 import { useHomeModeContext } from '@/pages/home/hooks/useHomeModeContext';
 import { usePatchActivateMode } from '@/pages/home/hooks/usePatchActivateMode';
 
@@ -23,13 +23,28 @@ export const useModeCard = ({
     handleModeSelect(modeId);
     activateMode(modeId);
   };
+  // 키보드(Enter/Space)로도 카드를 활성화할 수 있게 하는 함수
+  const handleActivateModeKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isDoNotDisturb) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+
+    event.preventDefault();
+    handleActivateModeClick();
+  };
+
   // 버튼을 눌렀을 때, 카드 클릭 이벤트가 같이 실행되지 않게 막는 함수
+  // 방해금지 모드에서는 설정 페이지로의 이동(기본 동작)도 함께 막는다.
   const handleMoveModeSettingClick = (event: MouseEvent<HTMLAnchorElement>) => {
     event.stopPropagation();
+
+    if (isDoNotDisturb) {
+      event.preventDefault();
+    }
   };
 
   return {
     handleActivateModeClick,
+    handleActivateModeKeyDown,
     handleMoveModeSettingClick,
   };
 };

--- a/src/pages/home/hooks/useModeCard.ts
+++ b/src/pages/home/hooks/useModeCard.ts
@@ -4,15 +4,21 @@ import { usePatchActivateMode } from '@/pages/home/hooks/usePatchActivateMode';
 
 interface UseModeCardParamTypes {
   modeId: number;
+  isDoNotDisturb: boolean;
 }
 
 // 모드 카드 한 장의 동작(카드 선택+활성화, 설정 이동 시 클릭 전파 차단)을 담당하는 훅
-export const useModeCard = ({ modeId }: UseModeCardParamTypes) => {
+export const useModeCard = ({
+  modeId,
+  isDoNotDisturb,
+}: UseModeCardParamTypes) => {
   const { handleModeSelect } = useHomeModeContext();
   const { mutate: activateMode } = usePatchActivateMode();
 
   // 카드 전체를 눌렀을 때, 해당 모드를 활성화하는 함수
   const handleActivateModeClick = () => {
+    if (isDoNotDisturb) return;
+
     // 화면 반응은 즉시 바꾸고, 서버의 활성 모드는 mutation으로 맞춘다.
     handleModeSelect(modeId);
     activateMode(modeId);

--- a/src/pages/home/hooks/useModeList.ts
+++ b/src/pages/home/hooks/useModeList.ts
@@ -4,7 +4,8 @@ import { useHomeModeContext } from '@/pages/home/hooks/useHomeModeContext';
 
 // 홈 화면 모드 목록의 데이터/상태를 묶는 훅. 첫 진입 시 활성 모드(없으면 첫 모드)를 기본 선택해준다.
 export const useModeList = () => {
-  const { selectedModeId, handleModeSelect } = useHomeModeContext();
+  const { selectedModeId, isDoNotDisturb, handleModeSelect } =
+    useHomeModeContext();
   const { data, isLoading, isError } = useGetModes();
 
   useEffect(() => {
@@ -20,6 +21,7 @@ export const useModeList = () => {
   return {
     modes: data?.modes ?? [],
     selectedModeId,
+    isDoNotDisturb,
     isLoading,
     isError,
   };

--- a/src/pages/home/hooks/useModeSoundSelectSection.ts
+++ b/src/pages/home/hooks/useModeSoundSelectSection.ts
@@ -41,6 +41,7 @@ export const useModeSoundSelectSection = () => {
   const [openedCategoryId, setOpenedCategoryId] = useState<number | null>(null);
 
   const sounds = useMemo(() => soundsData?.sounds ?? [], [soundsData?.sounds]);
+  const hasSounds = sounds.length > 0;
   const categories = useMemo(
     () => categoriesData?.categories ?? createCategoriesFromSounds(sounds),
     [categoriesData?.categories, sounds],
@@ -81,8 +82,10 @@ export const useModeSoundSelectSection = () => {
   return {
     categorySoundGroups,
     hasNoSearchResult,
-    isError: isSoundsError || isCategoriesError,
-    isLoading: isSoundsLoading || isCategoriesLoading,
+    // 소리 목록만 있으면 카테고리는 합성 폴백으로 대체되므로,
+    // 소리가 없을 때에만 카테고리 에러/로딩을 섹션 차단 사유로 본다.
+    isError: isSoundsError || (!hasSounds && isCategoriesError),
+    isLoading: isSoundsLoading || (!hasSounds && isCategoriesLoading),
     isSearching,
     openedCategoryId,
     searchKeyword,

--- a/src/pages/home/hooks/useModeSoundSelectSection.ts
+++ b/src/pages/home/hooks/useModeSoundSelectSection.ts
@@ -1,0 +1,92 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useGetSoundCategories } from '@/pages/home/hooks/useGetSoundCategories';
+import { useGetSounds } from '@/pages/home/hooks/useGetSounds';
+import type {
+  CategoryTypes,
+  SoundTypes,
+} from '@/pages/home/types/soundTypes';
+
+interface CategorySoundGroupTypes {
+  category: CategoryTypes;
+  sounds: SoundTypes[];
+}
+
+const createCategoriesFromSounds = (sounds: SoundTypes[]) => {
+  const categoryMap = new Map<number, CategoryTypes>();
+
+  sounds.forEach((sound) => {
+    if (!categoryMap.has(sound.category_id)) {
+      categoryMap.set(sound.category_id, {
+        category_id: sound.category_id,
+        name: sound.category_name,
+      });
+    }
+  });
+
+  return [...categoryMap.values()];
+};
+
+export const useModeSoundSelectSection = () => {
+  const {
+    data: soundsData,
+    isLoading: isSoundsLoading,
+    isError: isSoundsError,
+  } = useGetSounds();
+  const {
+    data: categoriesData,
+    isLoading: isCategoriesLoading,
+    isError: isCategoriesError,
+  } = useGetSoundCategories();
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [openedCategoryId, setOpenedCategoryId] = useState<number | null>(null);
+
+  const sounds = useMemo(() => soundsData?.sounds ?? [], [soundsData?.sounds]);
+  const categories = useMemo(
+    () => categoriesData?.categories ?? createCategoriesFromSounds(sounds),
+    [categoriesData?.categories, sounds],
+  );
+  const trimmedSearchKeyword = searchKeyword.trim();
+  const isSearching = trimmedSearchKeyword.length > 0;
+
+  const categorySoundGroups = useMemo<CategorySoundGroupTypes[]>(() => {
+    const lowerSearchKeyword = trimmedSearchKeyword.toLowerCase();
+    const filteredSounds = isSearching
+      ? sounds.filter((sound) =>
+          sound.name.toLowerCase().includes(lowerSearchKeyword),
+        )
+      : sounds;
+
+    return categories
+      .map((category) => ({
+        category,
+        sounds: filteredSounds.filter(
+          (sound) => sound.category_id === category.category_id,
+        ),
+      }))
+      .filter(({ sounds: groupSounds }) => !isSearching || groupSounds.length);
+  }, [categories, isSearching, sounds, trimmedSearchKeyword]);
+
+  const hasNoSearchResult = isSearching && categorySoundGroups.length === 0;
+
+  const handleSearchKeywordChange = useCallback((keyword: string) => {
+    setSearchKeyword(keyword);
+  }, []);
+
+  const handleCategoryToggleClick = useCallback((categoryId: number) => {
+    setOpenedCategoryId((prevOpenedCategoryId) =>
+      prevOpenedCategoryId === categoryId ? null : categoryId,
+    );
+  }, []);
+
+  return {
+    categorySoundGroups,
+    hasNoSearchResult,
+    isError: isSoundsError || isCategoriesError,
+    isLoading: isSoundsLoading || isCategoriesLoading,
+    isSearching,
+    openedCategoryId,
+    searchKeyword,
+    handleCategoryToggleClick,
+    handleSearchKeywordChange,
+  };
+};

--- a/src/pages/home/hooks/useModeSoundState.ts
+++ b/src/pages/home/hooks/useModeSoundState.ts
@@ -4,7 +4,6 @@ interface ModeSoundStateTypes {
   isEditMode: boolean;
   isAddSoundModalOpen: boolean;
   selectedRemoveSoundIds: number[];
-  disabledSoundIdsByMode: Record<number, number[]>;
 }
 
 type ModeSoundActionTypes =
@@ -13,14 +12,12 @@ type ModeSoundActionTypes =
   | { type: 'OPEN_ADD_SOUND_MODAL' }
   | { type: 'CLOSE_ADD_SOUND_MODAL' }
   | { type: 'TOGGLE_REMOVE_SOUND'; soundId: number }
-  | { type: 'RESET_REMOVE_SOUNDS' }
-  | { type: 'TOGGLE_DISABLED_SOUND'; modeId: number; soundId: number };
+  | { type: 'RESET_REMOVE_SOUNDS' };
 
 const INITIAL_MODE_SOUND_STATE: ModeSoundStateTypes = {
   isEditMode: false,
   isAddSoundModalOpen: false,
   selectedRemoveSoundIds: [],
-  disabledSoundIdsByMode: {},
 };
 
 const toggleNumberInList = (numbers: number[], targetNumber: number) => {
@@ -72,24 +69,12 @@ const modeSoundReducer = (
         ...state,
         selectedRemoveSoundIds: [],
       };
-    case 'TOGGLE_DISABLED_SOUND': {
-      const disabledSoundIds =
-        state.disabledSoundIdsByMode[action.modeId] ?? [];
-
-      return {
-        ...state,
-        disabledSoundIdsByMode: {
-          ...state.disabledSoundIdsByMode,
-          [action.modeId]: toggleNumberInList(disabledSoundIds, action.soundId),
-        },
-      };
-    }
     default:
       return state;
   }
 };
 
-// 편집 모드, 모달 열림 상태, 삭제 선택 목록, 비활성 소리 목록 같은 UI 상태를 관리하는 훅
+// 편집 모드, 모달 열림 상태, 삭제 선택 목록 같은 UI 상태를 관리하는 훅
 export const useModeSoundState = () => {
   const [state, dispatch] = useReducer(
     modeSoundReducer,
@@ -120,10 +105,6 @@ export const useModeSoundState = () => {
     dispatch({ type: 'RESET_REMOVE_SOUNDS' });
   }, []);
 
-  const toggleDisabledSound = useCallback((modeId: number, soundId: number) => {
-    dispatch({ type: 'TOGGLE_DISABLED_SOUND', modeId, soundId });
-  }, []);
-
   return {
     state,
     toggleEditMode,
@@ -132,6 +113,5 @@ export const useModeSoundState = () => {
     closeAddSoundModal,
     toggleRemoveSound,
     resetRemoveSounds,
-    toggleDisabledSound,
   };
 };

--- a/src/pages/home/hooks/usePatchModeSoundActive.ts
+++ b/src/pages/home/hooks/usePatchModeSoundActive.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchModeSoundActive } from '@/pages/home/apis/patchModeSoundActive';
+import type { GetModeDetailResponseTypes } from '@/pages/home/types/modeTypes';
+
+interface PatchModeSoundActiveParamTypes {
+  modeId: number;
+  soundId: number;
+  isActive: boolean;
+}
+
+export const usePatchModeSoundActive = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      modeId,
+      soundId,
+      isActive,
+    }: PatchModeSoundActiveParamTypes) =>
+      patchModeSoundActive(modeId, soundId, { is_active: isActive }),
+    onSuccess: (data) => {
+      queryClient.setQueryData<GetModeDetailResponseTypes>(
+        ['modes', data.mode_id],
+        (old) => {
+          if (!old) return old;
+
+          return {
+            ...old,
+            sounds: old.sounds.map((sound) =>
+              sound.sound_id === data.sound_id
+                ? { ...sound, is_active: data.is_active }
+                : sound,
+            ),
+          };
+        },
+      );
+    },
+  });
+};

--- a/src/pages/home/hooks/usePutMode.ts
+++ b/src/pages/home/hooks/usePutMode.ts
@@ -80,6 +80,7 @@ export const usePutMode = () => {
               return {
                 ...sound,
                 category: oldSound?.category ?? '',
+                is_active: oldSound?.is_active ?? true,
               };
             }),
           };

--- a/src/pages/home/hooks/usePutModeSounds.ts
+++ b/src/pages/home/hooks/usePutModeSounds.ts
@@ -70,6 +70,7 @@ export const usePutModeSounds = () => {
                 ...sound,
                 category:
                   oldSound?.category ?? currentSound?.category_name ?? '',
+                is_active: oldSound?.is_active ?? true,
               };
             }),
           };

--- a/src/pages/home/hooks/useSoundSection.ts
+++ b/src/pages/home/hooks/useSoundSection.ts
@@ -12,7 +12,8 @@ export const useSoundSection = () => {
   const { selectedModeId, isDoNotDisturb } = useHomeModeContext();
   const { data, isLoading, isError } = useGetModeDetail(selectedModeId);
   const { mutateAsync: deleteModeSound } = useDeleteModeSound();
-  const { mutate: patchModeSoundActive } = usePatchModeSoundActive();
+  const { mutate: patchModeSoundActive, isPending: isPatchModeSoundActivePending } =
+    usePatchModeSoundActive();
   const { mutate: putModeSounds } = usePutModeSounds();
   const {
     state,
@@ -34,6 +35,9 @@ export const useSoundSection = () => {
         return;
       }
 
+      // on/off PATCH가 진행 중이면 연타로 인한 중복 요청을 막는다.
+      if (isPatchModeSoundActivePending) return;
+
       const selectedSound = data?.sounds.find(
         (sound) => sound.sound_id === soundId,
       );
@@ -48,6 +52,7 @@ export const useSoundSection = () => {
     [
       data?.sounds,
       isDoNotDisturb,
+      isPatchModeSoundActivePending,
       patchModeSoundActive,
       selectedModeId,
       state.isEditMode,

--- a/src/pages/home/hooks/useSoundSection.ts
+++ b/src/pages/home/hooks/useSoundSection.ts
@@ -8,7 +8,7 @@ import type { SoundTypes } from '@/pages/home/types/soundTypes';
 
 // 선택된 모드의 "담은 소리" 섹션 전체를 총괄하는 훅. 상세 조회 + 편집/모달 UI 상태 + 소리 추가/삭제 로직을 한곳에 모은다.
 export const useSoundSection = () => {
-  const { selectedModeId } = useHomeModeContext();
+  const { selectedModeId, isDoNotDisturb } = useHomeModeContext();
   const { data, isLoading, isError } = useGetModeDetail(selectedModeId);
   const { mutateAsync: deleteModeSound } = useDeleteModeSound();
   const { mutate: putModeSounds } = usePutModeSounds();
@@ -32,7 +32,7 @@ export const useSoundSection = () => {
   // 소리 카드 클릭 함수
   const handleSoundCardClick = useCallback(
     (soundId: number) => {
-      if (selectedModeId === null) return;
+      if (selectedModeId === null || isDoNotDisturb) return;
 
       if (state.isEditMode) {
         toggleRemoveSound(soundId);
@@ -41,12 +41,22 @@ export const useSoundSection = () => {
 
       toggleDisabledSound(selectedModeId, soundId);
     },
-    [selectedModeId, state.isEditMode, toggleDisabledSound, toggleRemoveSound],
+    [
+      isDoNotDisturb,
+      selectedModeId,
+      state.isEditMode,
+      toggleDisabledSound,
+      toggleRemoveSound,
+    ],
   );
 
   // 선택된 소리 삭제 함수
   const handleRemoveSelectedSoundsClick = useCallback(async () => {
-    if (selectedModeId === null || state.selectedRemoveSoundIds.length === 0) {
+    if (
+      selectedModeId === null ||
+      isDoNotDisturb ||
+      state.selectedRemoveSoundIds.length === 0
+    ) {
       return;
     }
 
@@ -61,6 +71,7 @@ export const useSoundSection = () => {
   }, [
     closeEditMode,
     deleteModeSound,
+    isDoNotDisturb,
     resetRemoveSounds,
     selectedModeId,
     state.selectedRemoveSoundIds,
@@ -69,7 +80,7 @@ export const useSoundSection = () => {
   // 소리 추가 완료 함수
   const handleAddSoundsComplete = useCallback(
     (selectedSounds: SoundTypes[]) => {
-      if (selectedModeId === null || !data) return;
+      if (selectedModeId === null || isDoNotDisturb || !data) return;
 
       const currentSounds = data.sounds.map((sound) => ({
         sound_id: sound.sound_id,
@@ -94,11 +105,12 @@ export const useSoundSection = () => {
       });
       closeAddSoundModal();
     },
-    [closeAddSoundModal, data, putModeSounds, selectedModeId],
+    [closeAddSoundModal, data, isDoNotDisturb, putModeSounds, selectedModeId],
   );
 
   return {
     selectedModeId,
+    isDoNotDisturb,
     sounds: data?.sounds ?? [],
     isLoading,
     isError,

--- a/src/pages/home/hooks/useSoundSection.ts
+++ b/src/pages/home/hooks/useSoundSection.ts
@@ -3,6 +3,7 @@ import { useDeleteModeSound } from '@/pages/home/hooks/useDeleteModeSound';
 import { useGetModeDetail } from '@/pages/home/hooks/useGetModeDetail';
 import { useHomeModeContext } from '@/pages/home/hooks/useHomeModeContext';
 import { useModeSoundState } from '@/pages/home/hooks/useModeSoundState';
+import { usePatchModeSoundActive } from '@/pages/home/hooks/usePatchModeSoundActive';
 import { usePutModeSounds } from '@/pages/home/hooks/usePutModeSounds';
 import type { SoundTypes } from '@/pages/home/types/soundTypes';
 
@@ -11,6 +12,7 @@ export const useSoundSection = () => {
   const { selectedModeId, isDoNotDisturb } = useHomeModeContext();
   const { data, isLoading, isError } = useGetModeDetail(selectedModeId);
   const { mutateAsync: deleteModeSound } = useDeleteModeSound();
+  const { mutate: patchModeSoundActive } = usePatchModeSoundActive();
   const { mutate: putModeSounds } = usePutModeSounds();
   const {
     state,
@@ -20,14 +22,7 @@ export const useSoundSection = () => {
     closeAddSoundModal,
     toggleRemoveSound,
     resetRemoveSounds,
-    toggleDisabledSound,
   } = useModeSoundState();
-
-  // 비활성 표시는 모드별로 따로 유지해 모드 전환 후에도 UI 선택을 보존한다.
-  const disabledSoundIds =
-    selectedModeId === null
-      ? []
-      : (state.disabledSoundIdsByMode[selectedModeId] ?? []);
 
   // 소리 카드 클릭 함수
   const handleSoundCardClick = useCallback(
@@ -39,13 +34,23 @@ export const useSoundSection = () => {
         return;
       }
 
-      toggleDisabledSound(selectedModeId, soundId);
+      const selectedSound = data?.sounds.find(
+        (sound) => sound.sound_id === soundId,
+      );
+      if (!selectedSound) return;
+
+      patchModeSoundActive({
+        modeId: selectedModeId,
+        soundId,
+        isActive: !selectedSound.is_active,
+      });
     },
     [
+      data?.sounds,
       isDoNotDisturb,
+      patchModeSoundActive,
       selectedModeId,
       state.isEditMode,
-      toggleDisabledSound,
       toggleRemoveSound,
     ],
   );
@@ -117,7 +122,6 @@ export const useSoundSection = () => {
     isEditMode: state.isEditMode,
     isAddSoundModalOpen: state.isAddSoundModalOpen,
     selectedRemoveSoundIds: state.selectedRemoveSoundIds,
-    disabledSoundIds,
     toggleEditMode,
     closeEditMode,
     openAddSoundModal,

--- a/src/pages/home/mocks/modeMock.ts
+++ b/src/pages/home/mocks/modeMock.ts
@@ -39,11 +39,13 @@ export const modeDetailMock: GetModeDetailResponseTypes = {
       sound_id: 1,
       name: '자동차 경적',
       category: '교통',
+      is_active: true,
     },
     {
       sound_id: 2,
       name: '사이렌',
       category: '위험',
+      is_active: false,
     },
   ],
 };

--- a/src/pages/home/types/modeTypes.ts
+++ b/src/pages/home/types/modeTypes.ts
@@ -5,6 +5,7 @@ export interface ModeSoundTypes {
 
 export interface ModeDetailSoundTypes extends ModeSoundTypes {
   category: string;
+  is_active: boolean;
 }
 
 export interface ModeTypes {
@@ -54,5 +55,15 @@ export interface UpdateModeResponseTypes {
 
 export interface ActivateModeResponseTypes {
   mode_id: number;
+  is_active: boolean;
+}
+
+export interface UpdateModeSoundActiveRequestTypes {
+  is_active: boolean;
+}
+
+export interface UpdateModeSoundActiveResponseTypes {
+  mode_id: number;
+  sound_id: number;
   is_active: boolean;
 }

--- a/src/shared/apis/patchDoNotDisturb.ts
+++ b/src/shared/apis/patchDoNotDisturb.ts
@@ -1,0 +1,16 @@
+import type {
+  UpdateDoNotDisturbRequestTypes,
+  UserTypes,
+} from '@/shared/types/userTypes';
+import http from '@/shared/apis/axios';
+
+export const patchDoNotDisturb = async (
+  doNotDisturbData: UpdateDoNotDisturbRequestTypes,
+): Promise<UserTypes> => {
+  const response = await http.patch<UserTypes>(
+    '/users/me/do-not-disturb',
+    doNotDisturbData,
+  );
+
+  return response.data;
+};

--- a/src/shared/components/icons/DoNotDisturbIcon.tsx
+++ b/src/shared/components/icons/DoNotDisturbIcon.tsx
@@ -1,8 +1,8 @@
-interface SilentModeIconPropTypes {
+interface DoNotDisturbIconPropTypes {
   className?: string;
 }
 
-const SilentModeIcon = ({ className }: SilentModeIconPropTypes) => (
+const DoNotDisturbIcon = ({ className }: DoNotDisturbIconPropTypes) => (
   <svg
     viewBox="0 0 16 18"
     fill="none"
@@ -16,4 +16,4 @@ const SilentModeIcon = ({ className }: SilentModeIconPropTypes) => (
   </svg>
 );
 
-export default SilentModeIcon;
+export default DoNotDisturbIcon;

--- a/src/shared/hooks/usePatchDoNotDisturb.ts
+++ b/src/shared/hooks/usePatchDoNotDisturb.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { patchDoNotDisturb } from '@/shared/apis/patchDoNotDisturb';
+
+export const usePatchDoNotDisturb = () => {
+  return useMutation({
+    mutationFn: (doNotDisturb: boolean) =>
+      patchDoNotDisturb({ do_not_disturb: doNotDisturb }),
+  });
+};

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -90,10 +90,13 @@
   --spacing-xxxs: 0.125rem; /* 2px */
 
   /* Icon Size */
-  --spacing-icon-hero: 1.75rem; /* 28px */
-  --spacing-icon-lg: 1.5rem; /* 24px */
-  --spacing-icon-md: 1.25rem; /* 20px */
-  --spacing-icon-sm: 1rem; /* 16px */
+  --icon-sm: 1rem; /* 16px */
+  --icon-md: 1.5rem; /* 24px */
+  --icon-lg: 1.75rem; /* 28px */
+  --icon-xl: 2rem; /* 32px */
+  --icon-2xl: 2.25rem; /* 36px */
+  --icon-3xl: 3rem; /* 48px */
+  --icon-4xl: 3.5rem; /* 56px */
 
   /* Opacity */
   --opacity-opaque: 1;

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -338,6 +338,15 @@
   background-image: var(--gradient-default);
 }
 
+/* icon size - --icon-* 토큰을 width, height 유틸리티로 노출한다 */
+@utility w-icon-* {
+  width: --value(--icon- *);
+}
+
+@utility h-icon-* {
+  height: --value(--icon- *);
+}
+
 /* shadow */
 @utility shadow-chip {
   box-shadow: var(--shadow-chip);

--- a/src/shared/types/userTypes.ts
+++ b/src/shared/types/userTypes.ts
@@ -1,0 +1,12 @@
+export interface UserTypes {
+  id: number;
+  email: string;
+  nickname: string;
+  disability_type: string | null;
+  haptic_strength: number;
+  do_not_disturb: boolean;
+}
+
+export interface UpdateDoNotDisturbRequestTypes {
+  do_not_disturb: boolean;
+}


### PR DESCRIPTION
<!--
제목 작성은 이렇게 해주세요!
작업 종류: 작업한 항목 #이슈번호
ex) Feature: 로그인/회원가입 구현
ex) Remove: 로그인 일부 코드 삭제
-->
<!--PR 날리고 팀원들에게 알리기 (디스코드에 @everyone이라고 적어서 알려주세요) 📢-->

## #️⃣ 연관된 이슈

  - close #41
  - close #42
  - close #43
  - close #45 

  <br/>

  ## 💻 작업 내용

  > 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

  ### 방해금지 모드 API 연결

  - `PATCH /users/me/do-not-disturb` API를 연결했습니다.
  - `DoNotDisturbButton` 클릭 시 방해금지 상태를 토글하고 서버에 반영하도록 구현했습니다.
  - 현재 `GET /users/me` API가 아직 없어, 새로고침 시 방해금지 상태는 기본값으로 초기화됩니다.
  - API 실패 시 이전 상태로 복구되도록 처리했습니다.

  ### 방해금지 모드 활성화 시 UI/기능 비활성화

  - 방해금지 상태를 `HomeModeProvider`에서 관리하도록 변경했습니다.
  - 방해금지 모드가 켜져 있을 때:
    - 모드 카드 클릭 비활성화
    - 소리 카드 클릭 비활성화
    - 소리 편집/삭제/추가 버튼 비활성화
    - 모드 카드와 소리 카드에 비활성 스타일 적용

  ### 소리 on/off API 연결

  - `PATCH /api/v1/modes/{mode_id}/sounds/{sound_id}` API를 연결했습니다.
  - 소리 카드 클릭 시 현재 `is_active` 값을 반전해서 서버에 저장합니다.
  - 성공 시 TanStack Query 캐시의 해당 소리 `is_active`만 갱신하도록 구현했습니다.
  - 기존 로컬 reducer 기반의 임시 비활성 상태 관리를 제거하고, 서버 응답의 `is_active`를 기준으로 상태를 관리하도록 변경했습니
  다.

  ### 소리 카드 스타일링 수정

  - 소리 카드 상태를 다음 기준으로 정리했습니다.
    - 일반 모드 + 소리 on
    - 일반 모드 + 소리 off
    - 편집/추가 모드에서 선택됨
    - 방해금지 모드

  - 스타일은 다음 3가지로 통일했습니다.
    - on 스타일
    - off/default 스타일
    - 방해금지 비활성 스타일

  - 편집 모드와 소리 추가 모달에서는 테두리 없이 선택 여부에 따라 on/off 스타일만 바뀌도록 수정했습니다.
  - on/off 전환 시 `transition`과 `active:scale`을 적용해 더 부드럽게 동작하도록 개선했습니다.

++ 새 모드 추가하기 부분 ui를 수정했습니다

  ### 네이밍 정리

  - `SilentModeButton` → `DoNotDisturbButton`
  - `SilentModeIcon` → `DoNotDisturbIcon`

  <br/>

  ## 📸 스크린샷 (선택)

<img width="484" height="451" alt="image" src="https://github.com/user-attachments/assets/87f555be-e867-4ef4-89e9-12037d77e8cd" />


  <br/>

  ## 🌟 리뷰 요구사항

 

  <br/>

  ## 🔗 참고 자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 방해금지(Do Not Disturb) 토글 추가
  * 개별 사운드의 활성/비활성 전환 기능 추가

* **개선 사항**
  * 방해금지 상태에서 모드·사운드 상호작용 비활성화 및 관련 버튼 비활성/스타일 반영
  * 사운드 선택 UI 개선: 카테고리 확장/검색, 선택 블록 UI 강화
  * 아이콘 및 스타일 토큰 정비 (아이콘 크기 유틸 추가)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->