### PR TITLE
Fix: 하드웨어 테스트 시 푸시알림 미수신 문제 해결

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 // 이 파일은 Service Worker로 동작하므로 번들러(Vite)를 거치지 않는 정적 파일이다.
 // 따라서 import.meta.env / ES module import를 쓸 수 없고, compat SDK를 importScripts로 불러온다.
 // SDK 버전은 package.json의 firebase 버전(12.14.0)과 반드시 일치시킨다.
@@ -19,10 +18,11 @@ firebase.initializeApp({
 const messaging = firebase.messaging();
 
 // 앱이 백그라운드(탭 비활성/닫힘) 상태일 때 도착하는 푸시 메시지를 처리한다.
-// 백엔드는 data-only 페이로드를 보낸다(notification 키 없음). data-only는 브라우저가
-// 알림을 자동 표시하지 않으므로 여기서 직접 showNotification으로 띄운다.
-// 이렇게 해야 중복 표시(자동 1개 + 수동 1개)가 생기지 않고, notificationclick 핸들러도 항상 동작한다.
+// notification 페이로드는 브라우저가 자동 표시하므로 수동으로 다시 띄우지 않는다.
+// data-only 페이로드만 직접 표시해 두 형식을 모두 지원하면서 중복 알림을 방지한다.
 messaging.onBackgroundMessage((payload) => {
+  if (payload.notification) return;
+
   const { title, body } = payload.data ?? {};
   self.registration.showNotification(title ?? '알림', {
     body,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,13 @@ import { useLocation } from 'react-router-dom';
 
 import BottomNavigation from '@/layout/BottomNavigation';
 import AppRouter from '@/routes/AppRouter';
+import { useForegroundNotification } from '@/shared/hooks/useForegroundNotification';
 import '@/App.css';
 
 function App() {
   const { pathname } = useLocation();
+  useForegroundNotification();
+
   // 모드쪽 설정 페이지에서는 네비게이션 숨김
   const hideNavigation = pathname.startsWith('/modes/');
 

--- a/src/pages/setting/hooks/useFcmToken.ts
+++ b/src/pages/setting/hooks/useFcmToken.ts
@@ -1,7 +1,7 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 
 import { postFcmToken } from '@/pages/setting/apis/postFcmToken';
-import { requestFcmToken, onForegroundMessage } from '@/shared/firebase/settingFCM';
+import { requestFcmToken } from '@/shared/firebase/settingFCM';
 
 const getInitialPermission = (): NotificationPermission =>
   typeof Notification !== 'undefined' ? Notification.permission : 'default';
@@ -24,47 +24,6 @@ export const useFcmToken = () => {
     } catch (error) {
       console.error('[FCM] 토큰 서버 전송 실패:', error);
     }
-  }, []);
-
-  // foreground 메시지는 OS 알림을 자동으로 띄우지 않으므로 직접 알림을 생성한다.
-  // 백엔드는 data-only 페이로드를 보내므로 payload.data에서 제목/본문을 읽는다.
-  useEffect(() => {
-    const unsubscribe = onForegroundMessage((payload) => {
-      const { title, body } = payload.data ?? {};
-      if (Notification.permission !== 'granted' || !title) return;
-
-      const options: NotificationOptions = {
-        body,
-        icon: '/icons/android-chrome-192x192.png',
-      };
-
-      // Android Chrome 등 일부 모바일은 new Notification() 생성자가 Illegal constructor로 크래시한다.
-      // 따라서 SW의 showNotification을 우선 사용한다. 이렇게 띄운 알림 클릭은
-      // firebase-messaging-sw.js의 notificationclick 핸들러가 받아 탭 포커스를 처리하므로
-      // 여기서 따로 onclick을 붙일 필요가 없다(백/포그라운드 클릭 동작 일원화).
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.ready.then((registration) => {
-          registration.showNotification(title, options);
-        });
-        return;
-      }
-
-      // SW를 못 쓰는 환경(데스크톱 일부 등)을 위한 fallback. 생성자 미지원 시 크래시하지 않도록 감싼다.
-      try {
-        const notification = new Notification(title, options);
-
-        // 포그라운드에서 만든 Notification은 onclick이 없으면 클릭해도 아무 동작이 없다.
-        // 클릭 시 백그라운드로 가려진 탭을 다시 앞으로 가져온다.
-        notification.onclick = () => {
-          window.focus();
-          notification.close();
-        };
-      } catch (error) {
-        console.error('[FCM] 알림 생성 실패:', error);
-      }
-    });
-
-    return () => unsubscribe();
   }, []);
 
   return { token, permission, handleRequestPermission };

--- a/src/shared/firebase/settingFCM.ts
+++ b/src/shared/firebase/settingFCM.ts
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
-import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { deleteToken, getMessaging, getToken, onMessage } from 'firebase/messaging';
 import type { MessagePayload } from 'firebase/messaging';
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
@@ -60,7 +60,13 @@ export const requestFcmToken = async (): Promise<string | null> => {
   if (permission !== 'granted') return null;
 
   try {
+    if (!VAPID_KEY) {
+      throw new Error('VITE_FIREBASE_VAPID_KEY가 설정되지 않았습니다.');
+    }
+
     const serviceWorkerRegistration = await registerFcmServiceWorker();
+    await deleteToken(messaging);
+
     const token = await getToken(messaging, {
       vapidKey: VAPID_KEY,
       serviceWorkerRegistration,

--- a/src/shared/hooks/useForegroundNotification.ts
+++ b/src/shared/hooks/useForegroundNotification.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+
+import { onForegroundMessage } from '@/shared/firebase/settingFCM';
+
+export const useForegroundNotification = () => {
+  useEffect(() => {
+    const unsubscribe = onForegroundMessage((payload) => {
+      if (Notification.permission !== 'granted') return;
+
+      const title = payload.data?.title ?? payload.notification?.title ?? '알림';
+      const body = payload.data?.body ?? payload.notification?.body;
+      const options: NotificationOptions = {
+        body,
+        icon: '/icons/android-chrome-192x192.png',
+      };
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.ready
+          .then((registration) => registration.showNotification(title, options))
+          .catch((error) => {
+            console.error('[FCM] 포그라운드 알림 생성 실패:', error);
+          });
+        return;
+      }
+
+      try {
+        const notification = new Notification(title, options);
+        notification.onclick = () => {
+          window.focus();
+          notification.close();
+        };
+      } catch (error) {
+        console.error('[FCM] 포그라운드 알림 생성 실패:', error);
+      }
+    });
+
+    return unsubscribe;
+  }, []);
+};


### PR DESCRIPTION
## 📌 작업 내용

- 폐기된 FCM 토큰이 캐시에서 재사용되는 문제를 수정했습니다.
- 기존 FCM 토큰 삭제 후 신규 토큰을 발급하도록 변경했습니다.
- 포그라운드 메시지 리스너를 설정 페이지에서 앱 전역으로 이동했습니다.
- FCM의 `data-only` 및 `notification` 페이로드를 모두 처리하도록 개선했습니다.
- 백그라운드 알림의 중복 표시를 방지했습니다.
- VAPID 키 누락 시 오류를 확인할 수 있도록 처리했습니다.

## 🔍 문제 원인

서버 DB에 Firebase에서 폐기된 FCM 토큰이 저장되어 있었습니다.

브라우저가 해당 토큰을 캐시에서 다시 반환하면서 서버에서 다음 오류가 발생했습니다.

```text
FCM send failed: Device unregistered.
```

또한 포그라운드 메시지 리스너가 설정 페이지에서만 등록되어 다른 페이지에서는 알림을 표시할 수 없었습니다.

## ✅ 해결 방법

- `deleteToken()`으로 기존 캐시 토큰 삭제
- `getToken()`으로 신규 토큰 발급
- 신규 토큰을 백엔드에 다시 등록
- 포그라운드 알림 수신 Hook을 앱 루트에서 실행
- 서비스 워커에서 페이로드 형식에 따라 알림 표시 여부 분기

## 🧪 테스트

- 하드웨어 → AI 서버 → 백엔드 감지 요청 정상
- 감지 결과 DB 저장 정상
- 신규 FCM 토큰 서버 등록 정상
- 포그라운드 및 백그라운드 푸시 알림 수신 확인
- TypeScript 검사 통과
- 변경 파일 ESLint 통과

> 전체 프로덕션 빌드는 로컬 Tailwind 네이티브 바이너리 로딩 문제로 완료하지 못했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 백그라운드 푸시 알림에서 중복 표시되는 문제를 해결했습니다.
  * 알림 및 데이터 전용 페이로드 형식을 모두 올바르게 지원합니다.

* **개선 사항**
  * 포그라운드 상태에서 푸시 알림 수신 및 표시 기능을 개선했습니다.
  * FCM 토큰 관리 로직을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->