### PR TITLE
Fix: FCM 푸시 알림 미수신 및 토큰 동기화 개선

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 // 이 파일은 Service Worker로 동작하므로 번들러(Vite)를 거치지 않는 정적 파일이다.
 // 따라서 import.meta.env / ES module import를 쓸 수 없고, compat SDK를 importScripts로 불러온다.
 // SDK 버전은 package.json의 firebase 버전(12.14.0)과 반드시 일치시킨다.
@@ -19,10 +18,11 @@ firebase.initializeApp({
 const messaging = firebase.messaging();
 
 // 앱이 백그라운드(탭 비활성/닫힘) 상태일 때 도착하는 푸시 메시지를 처리한다.
-// 백엔드는 data-only 페이로드를 보낸다(notification 키 없음). data-only는 브라우저가
-// 알림을 자동 표시하지 않으므로 여기서 직접 showNotification으로 띄운다.
-// 이렇게 해야 중복 표시(자동 1개 + 수동 1개)가 생기지 않고, notificationclick 핸들러도 항상 동작한다.
+// notification 페이로드는 브라우저가 자동 표시하므로 수동으로 다시 띄우지 않는다.
+// data-only 페이로드만 직접 표시해 두 형식을 모두 지원하면서 중복 알림을 방지한다.
 messaging.onBackgroundMessage((payload) => {
+  if (payload.notification) return;
+
   const { title, body } = payload.data ?? {};
   self.registration.showNotification(title ?? '알림', {
     body,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import { useLocation } from 'react-router-dom';
 
 import BottomNavigation from '@/layout/BottomNavigation';
 import AppRouter from '@/routes/AppRouter';
+import { useFcmTokenSync } from '@/shared/hooks/useFcmTokenSync';
 import { useForegroundNotification } from '@/shared/hooks/useForegroundNotification';
 import '@/App.css';
 
 function App() {
   const { pathname } = useLocation();
+  useFcmTokenSync();
   useForegroundNotification();
 
   // 모드쪽 설정 페이지에서는 네비게이션 숨김

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,13 @@ import { useLocation } from 'react-router-dom';
 
 import BottomNavigation from '@/layout/BottomNavigation';
 import AppRouter from '@/routes/AppRouter';
+import { useForegroundNotification } from '@/shared/hooks/useForegroundNotification';
 import '@/App.css';
 
 function App() {
   const { pathname } = useLocation();
+  useForegroundNotification();
+
   // 모드쪽 설정 페이지에서는 네비게이션 숨김
   const hideNavigation = pathname.startsWith('/modes/');
 

--- a/src/pages/setting/hooks/useFcmToken.ts
+++ b/src/pages/setting/hooks/useFcmToken.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 
-import { postFcmToken } from '@/pages/setting/apis/postFcmToken';
+import { postFcmToken } from '@/shared/apis/postFcmToken';
 import { requestFcmToken } from '@/shared/firebase/settingFCM';
 
 const getInitialPermission = (): NotificationPermission =>

--- a/src/pages/setting/hooks/useFcmToken.ts
+++ b/src/pages/setting/hooks/useFcmToken.ts
@@ -1,7 +1,7 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 
 import { postFcmToken } from '@/pages/setting/apis/postFcmToken';
-import { requestFcmToken, onForegroundMessage } from '@/shared/firebase/settingFCM';
+import { requestFcmToken } from '@/shared/firebase/settingFCM';
 
 const getInitialPermission = (): NotificationPermission =>
   typeof Notification !== 'undefined' ? Notification.permission : 'default';
@@ -24,47 +24,6 @@ export const useFcmToken = () => {
     } catch (error) {
       console.error('[FCM] 토큰 서버 전송 실패:', error);
     }
-  }, []);
-
-  // foreground 메시지는 OS 알림을 자동으로 띄우지 않으므로 직접 알림을 생성한다.
-  // 백엔드는 data-only 페이로드를 보내므로 payload.data에서 제목/본문을 읽는다.
-  useEffect(() => {
-    const unsubscribe = onForegroundMessage((payload) => {
-      const { title, body } = payload.data ?? {};
-      if (Notification.permission !== 'granted' || !title) return;
-
-      const options: NotificationOptions = {
-        body,
-        icon: '/icons/android-chrome-192x192.png',
-      };
-
-      // Android Chrome 등 일부 모바일은 new Notification() 생성자가 Illegal constructor로 크래시한다.
-      // 따라서 SW의 showNotification을 우선 사용한다. 이렇게 띄운 알림 클릭은
-      // firebase-messaging-sw.js의 notificationclick 핸들러가 받아 탭 포커스를 처리하므로
-      // 여기서 따로 onclick을 붙일 필요가 없다(백/포그라운드 클릭 동작 일원화).
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.ready.then((registration) => {
-          registration.showNotification(title, options);
-        });
-        return;
-      }
-
-      // SW를 못 쓰는 환경(데스크톱 일부 등)을 위한 fallback. 생성자 미지원 시 크래시하지 않도록 감싼다.
-      try {
-        const notification = new Notification(title, options);
-
-        // 포그라운드에서 만든 Notification은 onclick이 없으면 클릭해도 아무 동작이 없다.
-        // 클릭 시 백그라운드로 가려진 탭을 다시 앞으로 가져온다.
-        notification.onclick = () => {
-          window.focus();
-          notification.close();
-        };
-      } catch (error) {
-        console.error('[FCM] 알림 생성 실패:', error);
-      }
-    });
-
-    return () => unsubscribe();
   }, []);
 
   return { token, permission, handleRequestPermission };

--- a/src/shared/apis/postFcmToken.ts
+++ b/src/shared/apis/postFcmToken.ts
@@ -1,7 +1,5 @@
 import http from '@/shared/apis/axios';
 
-// 발급받은 FCM 토큰을 서버에 등록한다.
-// 백엔드: POST /users/me/fcm-token, 바디 키는 snake_case(fcm_token)
 export const postFcmToken = async (fcmToken: string): Promise<void> => {
   await http.post('/users/me/fcm-token', { fcm_token: fcmToken });
 };

--- a/src/shared/firebase/settingFCM.ts
+++ b/src/shared/firebase/settingFCM.ts
@@ -24,6 +24,10 @@ export const messaging = getMessaging(app);
 // Firebase 콘솔 > Cloud Messaging > 웹 푸시 인증서에서 발급한 공개키
 const VAPID_KEY = import.meta.env.VITE_FIREBASE_VAPID_KEY;
 
+// FCM 백그라운드 SW의 scope. PWA용 sw.js(scope '/')와 충돌하지 않도록 분리한다.
+// 등록(register)과 조회(getRegistration)가 반드시 같은 값을 써야 하므로 상수로 공유한다.
+export const FCM_SW_SCOPE = '/firebase-cloud-messaging-push-scope';
+
 // 특정 Service Worker가 activated 상태가 될 때까지 기다린다.
 // navigator.serviceWorker.ready는 scope '/'의 PWA SW만 보장하므로,
 // 별도 scope로 등록한 FCM SW의 활성화는 이 registration의 SW를 직접 추적해야 한다.
@@ -44,7 +48,7 @@ const registerFcmServiceWorker = async () => {
   if (!('serviceWorker' in navigator)) return undefined;
 
   const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js', {
-    scope: '/firebase-cloud-messaging-push-scope',
+    scope: FCM_SW_SCOPE,
   });
 
   // register()는 등록만 보장하고 활성화는 보장하지 않는다.

--- a/src/shared/firebase/settingFCM.ts
+++ b/src/shared/firebase/settingFCM.ts
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
-import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { deleteToken, getMessaging, getToken, onMessage } from 'firebase/messaging';
 import type { MessagePayload } from 'firebase/messaging';
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
@@ -60,7 +60,13 @@ export const requestFcmToken = async (): Promise<string | null> => {
   if (permission !== 'granted') return null;
 
   try {
+    if (!VAPID_KEY) {
+      throw new Error('VITE_FIREBASE_VAPID_KEY가 설정되지 않았습니다.');
+    }
+
     const serviceWorkerRegistration = await registerFcmServiceWorker();
+    await deleteToken(messaging);
+
     const token = await getToken(messaging, {
       vapidKey: VAPID_KEY,
       serviceWorkerRegistration,

--- a/src/shared/firebase/settingFCM.ts
+++ b/src/shared/firebase/settingFCM.ts
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
-import { deleteToken, getMessaging, getToken, onMessage } from 'firebase/messaging';
+import { getMessaging, getToken, onMessage } from 'firebase/messaging';
 import type { MessagePayload } from 'firebase/messaging';
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
@@ -55,18 +55,13 @@ const registerFcmServiceWorker = async () => {
 
 // 알림 권한을 요청하고, 허용 시 FCM 토큰을 발급받는다.
 // 토큰은 이 기기를 식별하는 주소로, 서버(또는 Firebase 콘솔)가 이 토큰으로 푸시를 보낸다.
-export const requestFcmToken = async (): Promise<string | null> => {
-  const permission = await Notification.requestPermission();
-  if (permission !== 'granted') return null;
-
+export const getCurrentFcmToken = async (): Promise<string | null> => {
   try {
     if (!VAPID_KEY) {
       throw new Error('VITE_FIREBASE_VAPID_KEY가 설정되지 않았습니다.');
     }
 
     const serviceWorkerRegistration = await registerFcmServiceWorker();
-    await deleteToken(messaging);
-
     const token = await getToken(messaging, {
       vapidKey: VAPID_KEY,
       serviceWorkerRegistration,
@@ -78,6 +73,13 @@ export const requestFcmToken = async (): Promise<string | null> => {
     console.error('[FCM] 토큰 발급 실패:', error);
     return null;
   }
+};
+
+export const requestFcmToken = async (): Promise<string | null> => {
+  const permission = await Notification.requestPermission();
+  if (permission !== 'granted') return null;
+
+  return getCurrentFcmToken();
 };
 
 // 앱이 foreground(탭 활성) 상태일 때 도착하는 메시지를 구독한다.

--- a/src/shared/hooks/useFcmTokenSync.ts
+++ b/src/shared/hooks/useFcmTokenSync.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+import { postFcmToken } from '@/shared/apis/postFcmToken';
+import { getCurrentFcmToken } from '@/shared/firebase/settingFCM';
+
+export const useFcmTokenSync = () => {
+  useEffect(() => {
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+
+    let isCancelled = false;
+
+    const syncFcmToken = async () => {
+      const fcmToken = await getCurrentFcmToken();
+      if (isCancelled || !fcmToken) return;
+
+      try {
+        await postFcmToken(fcmToken);
+      } catch (error) {
+        console.error('[FCM] token sync failed:', error);
+      }
+    };
+
+    void syncFcmToken();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+};

--- a/src/shared/hooks/useForegroundNotification.ts
+++ b/src/shared/hooks/useForegroundNotification.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+
+import { onForegroundMessage } from '@/shared/firebase/settingFCM';
+
+export const useForegroundNotification = () => {
+  useEffect(() => {
+    const unsubscribe = onForegroundMessage((payload) => {
+      if (Notification.permission !== 'granted') return;
+
+      const title = payload.data?.title ?? payload.notification?.title ?? '알림';
+      const body = payload.data?.body ?? payload.notification?.body;
+      const options: NotificationOptions = {
+        body,
+        icon: '/icons/android-chrome-192x192.png',
+      };
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.ready
+          .then((registration) => registration.showNotification(title, options))
+          .catch((error) => {
+            console.error('[FCM] 포그라운드 알림 생성 실패:', error);
+          });
+        return;
+      }
+
+      try {
+        const notification = new Notification(title, options);
+        notification.onclick = () => {
+          window.focus();
+          notification.close();
+        };
+      } catch (error) {
+        console.error('[FCM] 포그라운드 알림 생성 실패:', error);
+      }
+    });
+
+    return unsubscribe;
+  }, []);
+};

--- a/src/shared/hooks/useForegroundNotification.ts
+++ b/src/shared/hooks/useForegroundNotification.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { onForegroundMessage } from '@/shared/firebase/settingFCM';
+import { FCM_SW_SCOPE, onForegroundMessage } from '@/shared/firebase/settingFCM';
 
 export const useForegroundNotification = () => {
   useEffect(() => {
@@ -15,8 +15,16 @@ export const useForegroundNotification = () => {
       };
 
       if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.ready
-          .then((registration) => registration.showNotification(title, options))
+        // 알림을 띄운 SW가 notificationclick 핸들러도 소유하므로, FCM SW(별도 scope)로 띄워야
+        // 클릭 시 firebase-messaging-sw.js의 탭 포커스/앱 열기 로직이 실행된다.
+        // serviceWorker.ready는 scope '/'의 PWA SW를 반환하므로 FCM scope를 직접 조회한다.
+        navigator.serviceWorker
+          .getRegistration(FCM_SW_SCOPE)
+          .then((registration) => {
+            if (registration) return registration.showNotification(title, options);
+            // FCM SW registration을 못 찾으면 현재 페이지를 제어하는 SW로 fallback한다.
+            return navigator.serviceWorker.ready.then((reg) => reg.showNotification(title, options));
+          })
           .catch((error) => {
             console.error('[FCM] 포그라운드 알림 생성 실패:', error);
           });


### PR DESCRIPTION
﻿## 📌 작업 내용

- 포그라운드 메시지 리스너를 설정 페이지에서 앱 전역으로 이동했습니다.
- FCM의 `data-only` 및 `notification` 페이로드를 모두 처리하도록 개선했습니다.
- 백그라운드 알림의 중복 표시를 방지했습니다.
- 앱 실행 시 현재 FCM 토큰을 백엔드와 자동 동기화합니다.
- FCM 토큰 등록 API를 공통 영역으로 이동했습니다.
- VAPID 키 누락 시 오류를 확인할 수 있도록 처리했습니다.

## 🔍 문제 원인

서버 DB에 Firebase에서 폐기된 FCM 토큰이 저장되어 있어 다음 오류가 발생했습니다.

```text
FCM send failed: Device unregistered.
```

기존에는 `deleteToken()`으로 브라우저 토큰을 강제로 삭제한 뒤 재발급했지만,
이는 매번 새로운 토큰을 생성하는 임시 처리였습니다.

또한 포그라운드 메시지 리스너가 설정 페이지에서만 등록되어 다른 페이지에서는
알림을 표시할 수 없었습니다.

## ✅ 해결 방법

- `deleteToken()` 강제 호출 제거
- 알림 권한이 허용된 경우 앱 실행 시 `getToken()`으로 현재 토큰 조회
- 조회한 토큰을 백엔드에 다시 등록하여 서버 토큰 최신화
- 포그라운드 알림 수신 Hook을 앱 루트에서 실행
- 서비스 워커에서 페이로드 형식에 따라 알림 표시 여부 분기

## 🧪 테스트

- 변경 파일 ESLint 통과
- TypeScript 검사 통과
- `git diff --check` 통과
- 하드웨어 → AI 서버 → 백엔드 감지 요청 확인
- 포그라운드 및 백그라운드 푸시 알림 수신 확인

## ⚠️ 참고

- 전체 ESLint는 기존 `dev-dist` 생성물 및 `home` 코드 오류로 실패했습니다.
- 프로덕션 빌드는 로컬 Tailwind 네이티브 바이너리 로딩 문제로 완료하지 못했습니다.

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 포그라운드에서 푸시 알림을 안정적으로 표시하는 동작이 추가되었습니다.
  * 알림 권한이 허용된 경우 기기 토큰을 자동으로 서버에 동기화합니다.

* **버그 수정**
  * 백그라운드에서 브라우저가 자동 표시한 알림을 서비스워커가 중복해서 재표시하던 문제를 방지했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->