### PR TITLE
Feature: 알림탭 페이지 UI 구현 #79

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,10 +26,14 @@ function App() {
       showToast({ soundName: sound_name, categoryName: sound_category }),
   });
 
-  // 모드쪽 설정 페이지와 설정 하위 서브페이지에서는 네비게이션 숨김
+  // 모드쪽 설정 페이지, 설정 하위 서브페이지, 알림 페이지에서는 네비게이션 숨김
   // ('/setting' 메인은 '/setting/'에 걸리지 않아 탭바가 유지된다)
+  // 알림 페이지는 TopNavigation으로 진입/뒤로가기 하는 서브 페이지라 탭바를 숨긴다
+  // (어떤 탭도 active가 되지 않는 어정쩡한 상태를 방지).
   const hideNavigation =
-    pathname.startsWith('/modes/') || pathname.startsWith('/setting/');
+    pathname.startsWith('/modes/') ||
+    pathname.startsWith('/setting/') ||
+    pathname === '/notifications';
 
   return (
     <div className="app">

--- a/src/layout/TopNavigation.tsx
+++ b/src/layout/TopNavigation.tsx
@@ -1,6 +1,16 @@
 import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+
+// 우측에 텍스트 대신 아이콘 버튼이 필요한 경우(예: 알림 페이지의 쓰레기통)에 사용한다.
+// 아이콘 단독 버튼은 라벨이 없으면 스크린리더가 용도를 읽지 못하므로 ariaLabel 을 필수로 둔다.
+interface RightIconButtonTypes {
+  icon: IconDefinition;
+  onClick: () => void;
+  ariaLabel: string;
+  colorClassName?: string;
+}
 
 interface TopNavigationPropTypes {
   title: string;
@@ -8,6 +18,8 @@ interface TopNavigationPropTypes {
   onRightClick?: () => void;
   rightVariant?: 'default' | 'active';
   isRightDisabled?: boolean;
+  // rightIconButton 이 있으면 rightText 보다 우선해서 렌더한다.
+  rightIconButton?: RightIconButtonTypes;
 }
 
 const TopNavigation = ({
@@ -16,6 +28,7 @@ const TopNavigation = ({
   onRightClick,
   rightVariant = 'default',
   isRightDisabled = false,
+  rightIconButton,
 }: TopNavigationPropTypes) => {
   const navigate = useNavigate();
 
@@ -41,8 +54,21 @@ const TopNavigation = ({
 
       <h1 className="text-center heading-lg-semibold text-primary">{title}</h1>
 
-      {/* 우측 버튼이 없어도 3번째 컬럼(64px)을 차지해 제목 중앙 정렬을 유지한다. */}
-      {rightText && onRightClick ? (
+      {/* 우측 버튼이 없어도 3번째 컬럼(64px)을 차지해 제목 중앙 정렬을 유지한다.
+          우선순위: 아이콘 버튼 > 텍스트 버튼 > 빈 placeholder. */}
+      {rightIconButton ? (
+        <button
+          type="button"
+          onClick={rightIconButton.onClick}
+          disabled={isRightDisabled}
+          aria-label={rightIconButton.ariaLabel}
+          className={`justify-self-end h-[1.5rem] w-[1.5rem] disabled:text-neutral-300 ${
+            rightIconButton.colorClassName ?? 'text-primary'
+          }`}
+        >
+          <FontAwesomeIcon icon={rightIconButton.icon} />
+        </button>
+      ) : rightText && onRightClick ? (
         <button
           type="button"
           onClick={onRightClick}

--- a/src/pages/home/NotificationPage.tsx
+++ b/src/pages/home/NotificationPage.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+
+import NotificationHeader from '@/pages/home/components/notification/NotificationHeader';
+import NotificationList from '@/pages/home/components/notification/NotificationList';
+import { NOTIFICATION_MOCK } from '@/pages/home/constants/notificationMock';
+
+const NotificationPage = () => {
+  // TODO(api): GET 알림 목록 API 연동 시 mock 대신 서버 데이터로 초기화한다.
+  const [notifications, setNotifications] = useState(NOTIFICATION_MOCK);
+  // 삭제(선택) 모드 여부.
+  const [isDeleteMode, setIsDeleteMode] = useState(false);
+  // 선택된 알림 id 집합. 불변성을 위해 갱신 시 항상 새 Set 을 만든다.
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const hasNotifications = notifications.length > 0;
+  const hasSelection = selectedIds.size > 0;
+  // 목록이 비어있지 않으면서 모든 항목이 선택된 상태인지(전체 선택/해제 토글 라벨 기준).
+  const isAllSelected =
+    hasNotifications && selectedIds.size === notifications.length;
+
+  // 삭제(선택) 모드를 빠져나가며 선택을 비운다. '닫기' 및 삭제 완료 후 공통으로 쓴다.
+  const closeDeleteMode = () => {
+    setIsDeleteMode(false);
+    setSelectedIds(new Set());
+  };
+
+  // 쓰레기통 클릭: 상태에 따라 3갈래로 분기한다.
+  const handleTrashClick = () => {
+    // 일반 모드 → 삭제(선택) 모드 진입.
+    if (!isDeleteMode) {
+      setIsDeleteMode(true);
+      return;
+    }
+
+    // 삭제 모드 + 선택 있음 → 선택 항목 삭제.
+    if (hasSelection) {
+      // TODO(api): DELETE 알림 API 호출로 선택 항목을 서버에서도 삭제한다.
+      setNotifications((prev) =>
+        prev.filter((notification) => !selectedIds.has(notification.id)),
+      );
+      closeDeleteMode();
+      return;
+    }
+
+    // 삭제 모드 + 선택 없음 → 모드만 종료.
+    closeDeleteMode();
+  };
+
+  // 전체 선택 토글: 이미 전부 선택돼 있으면 해제, 아니면 전부 선택.
+  const handleSelectAll = () => {
+    setSelectedIds(
+      isAllSelected
+        ? new Set()
+        : new Set(notifications.map((notification) => notification.id)),
+    );
+  };
+
+  // 개별 알림 선택 토글.
+  const handleSelect = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex min-h-dvh flex-col pb-[9.5rem]">
+      <NotificationHeader
+        isDeleteMode={isDeleteMode}
+        hasNotifications={hasNotifications}
+        hasSelection={hasSelection}
+        isAllSelected={isAllSelected}
+        onTrashClick={handleTrashClick}
+        onSelectAll={handleSelectAll}
+        onCloseDeleteMode={closeDeleteMode}
+      />
+
+      <NotificationList
+        notifications={notifications}
+        isDeleteMode={isDeleteMode}
+        selectedIds={selectedIds}
+        onSelect={handleSelect}
+      />
+    </div>
+  );
+};
+
+export default NotificationPage;

--- a/src/pages/home/components/HomeHeader.tsx
+++ b/src/pages/home/components/HomeHeader.tsx
@@ -1,18 +1,24 @@
+import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell } from '@fortawesome/free-solid-svg-icons';
 import DoNotDisturbButton from '@/pages/home/components/mode/DoNotDisturbButton';
 import { useHomeModeContext } from '@/pages/home/hooks/useHomeModeContext';
 
 const HomeHeader = () => {
+  const navigate = useNavigate();
   const { isDoNotDisturb, isDoNotDisturbPending, handleDoNotDisturbToggle } =
     useHomeModeContext();
+
+  const handleBellClick = () => {
+    navigate('/notifications');
+  };
 
   return (
     <header className="mb-[2.5rem] flex flex-col gap-[1.5rem]">
       {/* 상단 행: 제목 + 알림 아이콘 */}
       <div className="flex items-start justify-between">
         <h1 className="heading-5xl-semibold text-primary">소리 필터링</h1>
-        <button type="button" aria-label="알림">
+        <button type="button" aria-label="알림" onClick={handleBellClick}>
           <FontAwesomeIcon
             icon={faBell}
             className="h-[1.5rem] w-[1.5rem] text-primary"

--- a/src/pages/home/components/notification/NotificationBar.tsx
+++ b/src/pages/home/components/notification/NotificationBar.tsx
@@ -1,0 +1,88 @@
+import { getCategoryColor } from '@/pages/home/constants/categoryColors';
+import type { NotificationItemTypes } from '@/pages/home/types/notificationTypes';
+import SoundIconView from '@/shared/components/icons/sounds/SoundIconView';
+
+interface NotificationBarPropTypes {
+  notification: NotificationItemTypes;
+  isDeleteMode?: boolean;
+  isSelected?: boolean;
+  onSelect?: (id: number) => void;
+}
+
+const NotificationBar = ({
+  notification,
+  isDeleteMode = false,
+  isSelected = false,
+  onSelect,
+}: NotificationBarPropTypes) => {
+  const { id, soundName, category, relativeTime, absoluteTime } = notification;
+
+  const handleSelectClick = () => {
+    onSelect?.(id);
+  };
+
+  // 카드 배경 색 분기:
+  // - 삭제모드 + 선택됨: 앰버색 20% 투명 배경 + 회색 테두리(스크린샷의 선택 행).
+  // - 그 외: 기본 어두운 톤.
+  const cardStyle =
+    isDeleteMode && isSelected
+      ? 'bg-[#DF9A00]/20 border border-neutral-600'
+      : 'bg-neutral-900 border border-transparent';
+
+  const cardClassName = `flex w-full items-center gap-base rounded-xl px-sm py-sm text-left transition-colors duration-200 ease-out ${cardStyle}`;
+
+  // 아이콘 + 소리명 + 카테고리 + 시간. wrapper(button/div)와 무관하게 동일하다.
+  const cardContent = (
+    <>
+      {/* 좌측 소리 아이콘 */}
+      <SoundIconView
+        soundName={soundName}
+        categoryName={category}
+        className="h-[2.5rem] w-[2.5rem] shrink-0 text-[2rem] leading-none text-primary"
+      />
+
+      {/* 가운데: 소리명 + 카테고리 배지 */}
+      <div className="flex min-w-0 flex-1 flex-col gap-xxs">
+        <span className="body-lg-regular truncate text-primary">
+          {soundName}
+        </span>
+        <span
+          className={`caption-xs-medium w-fit whitespace-nowrap rounded-full px-xs py-xxxs shadow-chip ${getCategoryColor(
+            category,
+          )}`}
+        >
+          {category}
+        </span>
+      </div>
+
+      {/* 우측: 상대 시간 / 절대 시간 */}
+      <div className="flex shrink-0 flex-col items-end gap-xs text-right">
+        <span className="body-sm-regular text-primary">{relativeTime}</span>
+        <span className="body-sm-regular text-neutral-400">{absoluteTime}</span>
+      </div>
+    </>
+  );
+
+  // 일반 모드에서는 클릭 동작이 없으므로(추후 상세 이동 TODO) button 대신 비상호작용 div 로 렌더해
+  // 스크린리더/키보드 사용자가 '버튼'으로 오인하지 않도록 한다.
+  // TODO(api): 일반 모드 클릭으로 알림 상세/감지 위치 이동이 생기면 다시 button/Link 로 바꾼다.
+  if (!isDeleteMode) {
+    return (
+      <div className={`${cardClassName} cursor-default`}>{cardContent}</div>
+    );
+  }
+
+  // 삭제 모드: 선택 토글이 가능하므로 button + aria-pressed 로 선택 상태를 노출한다.
+  return (
+    <button
+      type="button"
+      onClick={handleSelectClick}
+      aria-pressed={isSelected}
+      className={`${cardClassName} cursor-pointer`}
+    >
+      {cardContent}
+    </button>
+  );
+};
+
+export default NotificationBar;

--- a/src/pages/home/components/notification/NotificationHeader.tsx
+++ b/src/pages/home/components/notification/NotificationHeader.tsx
@@ -1,0 +1,84 @@
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons';
+
+import TopNavigation from '@/layout/TopNavigation';
+
+interface NotificationHeaderPropTypes {
+  // 삭제(선택) 모드 여부. true 면 헤더 아래 '전체 선택 / 닫기' 행을 노출한다.
+  isDeleteMode: boolean;
+  // 쓰레기통 아이콘 노출 여부(빈 목록 화면에서는 숨긴다).
+  hasNotifications: boolean;
+  // 선택된 항목이 하나라도 있는지(쓰레기통 색을 빨강으로 바꾸는 기준).
+  hasSelection: boolean;
+  // 모든 항목이 선택됐는지(전체 선택/해제 토글 라벨 기준).
+  isAllSelected: boolean;
+  onTrashClick: () => void;
+  onSelectAll: () => void;
+  onCloseDeleteMode: () => void;
+}
+
+const NotificationHeader = ({
+  isDeleteMode,
+  hasNotifications,
+  hasSelection,
+  isAllSelected,
+  onTrashClick,
+  onSelectAll,
+  onCloseDeleteMode,
+}: NotificationHeaderPropTypes) => {
+  // 쓰레기통 색은 3가지 상태로 나뉜다.
+  // - 일반 모드(삭제모드 진입 전): 기본색
+  // - 삭제 모드 + 선택 없음: 비활성색(아직 삭제할 게 없음)
+  // - 삭제 모드 + 선택 있음: 경고색(삭제 가능 강조)
+  const getTrashColorClassName = () => {
+    if (!isDeleteMode) {
+      return 'text-primary';
+    }
+    return hasSelection ? 'text-state-alert' : 'text-disabled';
+  };
+
+  const trashColorClassName = getTrashColorClassName();
+
+  return (
+    // relative: 삭제모드 액션 행을 TopNavigation 의 mb-2xl 여백 공간 안에 absolute 로 겹쳐 넣기 위한 기준점.
+    <div className="relative flex flex-col">
+      <TopNavigation
+        title="알림"
+        // 알림이 없으면 쓰레기통 자체를 숨긴다(빈 목록 화면).
+        rightIconButton={
+          hasNotifications
+            ? {
+                icon: faTrashCan,
+                onClick: onTrashClick,
+                ariaLabel: '알림 삭제',
+                colorClassName: trashColorClassName,
+              }
+            : undefined
+        }
+      />
+
+      {/* 삭제모드일 때만: 전체 선택 / 닫기 액션 행.
+          디자인 의도상 이 행은 아래 목록을 밀어내지 않고 TopNavigation 의 하단 여백 안에 들어간다.
+          top = pt-[2.75rem](상단 패딩) + 1.5rem(제목 행 높이) + 0.81rem(제목 행 바로 아래 간격). */}
+      {isDeleteMode && (
+        <div className="absolute right-[1.06rem] top-[5.06rem] flex gap-base">
+          <button
+            type="button"
+            onClick={onSelectAll}
+            className="body-sm-regular text-secondary"
+          >
+            {isAllSelected ? '전체 해제' : '전체 선택'}
+          </button>
+          <button
+            type="button"
+            onClick={onCloseDeleteMode}
+            className="body-sm-regular text-secondary"
+          >
+            닫기
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NotificationHeader;

--- a/src/pages/home/components/notification/NotificationList.tsx
+++ b/src/pages/home/components/notification/NotificationList.tsx
@@ -1,0 +1,47 @@
+import NotificationBar from '@/pages/home/components/notification/NotificationBar';
+import type { NotificationItemTypes } from '@/pages/home/types/notificationTypes';
+
+interface NotificationListPropTypes {
+  notifications: NotificationItemTypes[];
+  isDeleteMode: boolean;
+  selectedIds: Set<number>;
+  onSelect: (id: number) => void;
+}
+
+const NotificationList = ({
+  notifications,
+  isDeleteMode,
+  selectedIds,
+  onSelect,
+}: NotificationListPropTypes) => {
+  // 알림이 하나도 없으면 빈 상태 문구를 보여준다.
+  if (notifications.length === 0) {
+    return (
+      <p className="body-sm-regular pt-[1rem] text-center text-secondary">
+        받은 알림이 없어요.
+      </p>
+    );
+  }
+
+  return (
+    <ul
+      className={`flex flex-col gap-base px-[1.34rem] transition-[padding] duration-200 ease-out ${
+        // 삭제모드에선 헤더의 액션 행(absolute)과 목록이 0.81rem 떨어지도록 위 여백을 준다.
+        isDeleteMode ? 'pt-[0.81rem]' : ''
+      }`}
+    >
+      {notifications.map((notification) => (
+        <li key={notification.id}>
+          <NotificationBar
+            notification={notification}
+            isDeleteMode={isDeleteMode}
+            isSelected={selectedIds.has(notification.id)}
+            onSelect={onSelect}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default NotificationList;

--- a/src/pages/home/constants/notificationMock.ts
+++ b/src/pages/home/constants/notificationMock.ts
@@ -1,0 +1,56 @@
+import type { NotificationItemTypes } from '@/pages/home/types/notificationTypes';
+
+// 알림 페이지 UI 확인용 mock 데이터.
+// TODO(api): GET 알림 목록 API 연동 시 이 상수 대신 서버 응답으로 교체한다.
+//            (빈 목록 화면 동작을 보려면 이 배열을 [] 로 바꿔 확인할 수 있다.)
+export const NOTIFICATION_MOCK: NotificationItemTypes[] = [
+  {
+    id: 1,
+    soundName: '아기 옹알이',
+    category: '생활음',
+    relativeTime: '1일 전',
+    absoluteTime: '26.04.09 13:01',
+  },
+  {
+    id: 2,
+    soundName: '아기 옹알이',
+    category: '생활음',
+    relativeTime: '1일 전',
+    absoluteTime: '26.04.09 13:01',
+  },
+  {
+    id: 3,
+    soundName: '화재 경보',
+    category: '긴급',
+    relativeTime: '1일 전',
+    absoluteTime: '26.04.09 13:01',
+  },
+  {
+    id: 4,
+    soundName: '화재 경보',
+    category: '긴급',
+    relativeTime: '1일 전',
+    absoluteTime: '26.04.09 13:01',
+  },
+  {
+    id: 5,
+    soundName: '아기 옹알이',
+    category: '생활음',
+    relativeTime: '1일 전',
+    absoluteTime: '26.04.09 13:01',
+  },
+  {
+    id: 6,
+    soundName: '화재 경보',
+    category: '긴급',
+    relativeTime: '1일 전',
+    absoluteTime: '26.04.09 13:01',
+  },
+  {
+    id: 7,
+    soundName: '아기 옹알이',
+    category: '생활음',
+    relativeTime: '1일 전',
+    absoluteTime: '26.04.09 13:01',
+  },
+];

--- a/src/pages/home/types/notificationTypes.ts
+++ b/src/pages/home/types/notificationTypes.ts
@@ -1,0 +1,15 @@
+// 알림 페이지에서 사용하는 알림 한 건의 타입.
+// 현재는 UI 전용 mock 이라 표시용 문자열(relativeTime/absoluteTime)을 그대로 들고 있다.
+// TODO(api): 실제 알림 목록 API 연동 시 서버는 detected_at(datetime) 등을 내려줄 가능성이 높다.
+//            그 경우 datetime 원본을 받아 포맷 함수로 relativeTime/absoluteTime 을 계산하도록 바꾼다.
+export interface NotificationItemTypes {
+  id: number;
+  // 소리명(아이콘 매핑 키로도 사용). 예: '아기 옹알이', '화재 경보'
+  soundName: string;
+  // 카테고리명(배지 색 매핑 키). 예: '생활음', '긴급'
+  category: string;
+  // 우측 상단 상대 시간 표시. 예: '1일 전'
+  relativeTime: string;
+  // 우측 하단 절대 시간 표시. 예: '26.04.09 13:01'
+  absoluteTime: string;
+}

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import Home from '@/pages/home/Home';
 import ModeCreatePage from '@/pages/home/ModeCreatePage';
 import ModeEditPage from '@/pages/home/ModeEditPage';
+import NotificationPage from '@/pages/home/NotificationPage';
 import Communication from '@/pages/communication/Communication';
 import LiveSound from '@/pages/liveSound/LiveSound';
 import Setting from '@/pages/setting/Setting';
@@ -17,6 +18,7 @@ const AppRouter = () => {
       <Route path="/login" element={<Login />} />
       <Route path="/modes/new" element={<ModeCreatePage />} />
       <Route path="/modes/:modeId/settings" element={<ModeEditPage />} />
+      <Route path="/notifications" element={<NotificationPage />} />
       <Route path="/communication" element={<Communication />} />
       <Route path="/live-sound" element={<LiveSound />} />
       <Route path="/setting" element={<Setting />} />


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #79

<br/>

## 💻 작업 내용

> 종(faBell) 아이콘 클릭 시 진입하는 알림탭 페이지를 구현했습니다. (현재 API 미연동, UI/mock 기반)

- **진입 동선**: 홈 헤더 종 아이콘 → `/notifications` 라우트 추가 및 이동 연결
- **구조**: `NotificationPage`(상태/핸들러) → `NotificationHeader` + `NotificationList` → `NotificationBar`로 관심사 분리
- **삭제(선택) 모드**: 쓰레기통 토글로 진입 → 항목 선택 → 선택 시 쓰레기통이 경고색으로 전환되며 삭제. 전체 선택/해제, 닫기 지원
- **빈 상태**: 알림이 없으면 "받은 알림이 없어요" 문구 노출, 쓰레기통 숨김
- **공통 컴포넌트 확장**: `TopNavigation`에 우측 아이콘 버튼 슬롯(`rightIconButton`) 추가. 아이콘 단독 버튼은 `ariaLabel`을 타입상 필수로 강제
- **하단 탭바**: 알림 페이지는 서브 페이지라 탭바를 숨김(어떤 탭도 active 안 되는 상태 방지)
- **접근성**: 일반 모드 알림바는 클릭 동작이 없어 비상호작용 `div`로 렌더(스크린리더 오인 방지). 삭제 모드에서만 `button` + `aria-pressed`
- API 연동 지점은 `TODO(api)` 주석으로 표시 (목록 조회 / 삭제)

<br/>

## 📸 스크린샷 (선택)

다음과 같이 구현했습니다 *지금은 mock 데이터임 추후 api 연결 필요

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6371ecd6-ddd4-47d6-8f53-a98eb8bbdab1" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ce92b7de-47b1-4ecf-9a9e-21f7389f7b80" />



<br/>

## 🌟 리뷰 요구사항

- `TopNavigation`의 `rightIconButton` 객체 prop 방식이 적절한지(기존 텍스트 사용처 3곳은 무영향)
- 삭제 모드 색 상태 전환(쓰레기통: 기본 → disabled → alert, 알림바 선택 강조색 `#DF9A00`)이 시안과 맞는지
- 선택 강조 배경색을 `state-active` 토큰으로 바꾸는 게 좋을지 의견 (현재는 hex 직접 사용)

<br/>

## 🔗 참고 자료



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 알림 화면이 새로 추가되어, 홈의 알림 버튼에서 바로 이동할 수 있습니다.
  * 알림 목록에서 개별 선택, 전체 선택, 선택 삭제가 가능해졌습니다.
  * 상단 내비게이션의 우측 영역에 아이콘 버튼을 표시할 수 있게 되었습니다.

* **Bug Fixes**
  * `/notifications` 화면에서는 하단 내비게이션이 숨겨지도록 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->