### PR TITLE
fix: 만료 토큰으로 인한 로그인 페이지 무한 리다이렉트 루프 해결

### DIFF
--- a/src/shared/apis/axios.ts
+++ b/src/shared/apis/axios.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
-import { getAccessToken } from '@/pages/login/utils/tokenStorage';
+import { getAccessToken, removeAuthTokens } from '@/pages/login/utils/tokenStorage';
+
+const LOGIN_PATH = '/login';
 
 const http = axios.create({
   baseURL: import.meta.env.VITE_APP_BASE_URL, //추후 env에 백 배포 url 추가
@@ -23,9 +25,17 @@ http.interceptors.request.use((config) => {
 http.interceptors.response.use(
   (response) => response,
   (error) => {
-    // 에러 처리
+    // 401은 토큰 만료/무효를 의미한다. 죽은 토큰을 지우지 않으면 로그인 페이지로
+    // 리로드된 뒤에도 마운트 시 실행되는 요청들이 같은 토큰으로 다시 401을 맞아
+    // 리로드→요청→401→리로드의 무한 루프에 빠진다.
     if (error.response?.status === 401) {
-      window.location.href = '/login'; // 로그인 페이지로 리다이렉션
+      removeAuthTokens();
+      // 이미 로그인 페이지라면 리다이렉트하지 않는다. window.location.href는
+      // SPA 전체를 리로드시키므로, 같은 경로로 반복 대입하면 화면이 깜빡이며
+      // effect가 처음부터 다시 도는 원인이 된다.
+      if (window.location.pathname !== LOGIN_PATH) {
+        window.location.href = LOGIN_PATH;
+      }
     }
     return Promise.reject(error); // 에러를 호출한 곳으로 전달
   },

--- a/src/shared/hooks/useFcmTokenSync.ts
+++ b/src/shared/hooks/useFcmTokenSync.ts
@@ -2,10 +2,14 @@ import { useEffect } from 'react';
 
 import { postFcmToken } from '@/shared/apis/postFcmToken';
 import { getCurrentFcmToken } from '@/shared/firebase/settingFCM';
+import { getAccessToken } from '@/pages/login/utils/tokenStorage';
 
 export const useFcmTokenSync = () => {
   useEffect(() => {
     if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+    // 로그인 전(토큰 없음)에는 서버에 등록하지 않는다. 만료/무효 토큰으로 호출하면
+    // 401이 나고 인터셉터가 로그인으로 리다이렉트시키므로, 애초에 두드리지 않는다.
+    if (!getAccessToken()) return;
 
     let isCancelled = false;
 


### PR DESCRIPTION
- axios 응답 인터셉터에서 401 시 만료 토큰 제거(removeAuthTokens)
- 이미 /login이면 재리다이렉트 스킵하여 리로드 순환 차단
- useFcmTokenSync는 토큰 없으면 서버 호출하지 않도록 가드 추가

<!--
제목 작성은 이렇게 해주세요!
작업 종류: 작업한 항목 #이슈번호
ex) Feature: 로그인/회원가입 구현
ex) Remove: 로그인 일부 코드 삭제
-->
<!--PR 날리고 팀원들에게 알리기 (디스코드에 @everyone이라고 적어서 알려주세요) 📢-->

## #️⃣ 연관된 이슈

<!-- 이슈 번호를 작성해 주세요! ex) #11-->

- close #이슈번호

<br/>

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

<br/>

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

<br/>

## 🌟 리뷰 요구사항

<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. ex) 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요? -->

<br/>

## 🔗 참고 자료

<!--관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 인증이 만료되거나 유효하지 않을 때 인증 토큰을 삭제하고 로그인 페이지로 이동합니다.
  - 로그인 페이지에서 불필요한 반복 리다이렉트를 방지합니다.
  - 로그인 토큰이 없으면 알림 토큰 동기화를 실행하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->