### PR TITLE
fix: 요소에 커서 잡히는 문제 해결

### DIFF
--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -4,6 +4,12 @@
 
 * {
   box-sizing: border-box;
+  user-select: none;
+}
+input,
+textarea,
+[contenteditable='true'] {
+  user-select: text;
 }
 
 body {


### PR DESCRIPTION
<!--
제목 작성은 이렇게 해주세요!
작업 종류: 작업한 항목 #이슈번호
ex) Feature: 로그인/회원가입 구현
ex) Remove: 로그인 일부 코드 삭제
-->
<!--PR 날리고 팀원들에게 알리기 (디스코드에 @everyone이라고 적어서 알려주세요) 📢-->

## #️⃣ 연관된 이슈

<!-- 이슈 번호를 작성해 주세요! ex) #11-->

- close #103 

<br/>

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

화면에서 요소들에 커서 잡히는 게 싫어서 해결했어요 
```css
* {
  box-sizing: border-box;
  user-select: none;
}
input,
textarea,
[contenteditable='true'] {
  user-select: text;
}
```

이렇게 했습니다 `input`이랑 `textarea`는 선택 가능하게 했어요 (feat. 클로드)



<br/>

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

<img width="461" height="359" alt="image" src="https://github.com/user-attachments/assets/f244312a-fda5-4881-b6da-1562a6771a5a" />


이제 아무리 눌러도 안 잡혀요~~

<br/>

## 🌟 리뷰 요구사항

<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. ex) 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요? -->

제미나이가 사용자 경험 측면을 얘기했는데, 스크린 리더 사용에는 아무 관련이 없고 그냥 사용자가 글자 복붙을 못한다는 건데
추후 양방향 소통 기능에서 채팅 버블 정도..?만 필요할 것 같아서 그때 예외적으로 추가하면 될 것 같아요

<br/>

## 🔗 참고 자료

<!--관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 기본적으로 화면의 텍스트 선택을 비활성화했습니다.
  * 입력창, 텍스트 영역 및 편집 가능한 영역에서는 텍스트를 계속 선택하고 편집할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->