### PR TITLE
Fix: access token 만료 시 자동 refresh 처리

### DIFF
--- a/src/shared/apis/axios.ts
+++ b/src/shared/apis/axios.ts
@@ -1,6 +1,14 @@
 import axios from 'axios';
 
-import { getAccessToken, removeAuthTokens } from '@/pages/login/utils/tokenStorage';
+import {
+  getAccessToken,
+  getRefreshToken,
+  removeAuthTokens,
+  setAuthTokens,
+} from '@/pages/login/utils/tokenStorage';
+
+import type { AuthTokenResponseTypes } from '@/pages/login/types/loginTypes';
+import type { InternalAxiosRequestConfig } from 'axios';
 
 const LOGIN_PATH = '/login';
 
@@ -13,6 +21,54 @@ const http = axios.create({
   withCredentials: true,
 });
 
+const refreshClient = axios.create({
+  baseURL: import.meta.env.VITE_APP_BASE_URL,
+  timeout: 5000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+});
+
+const postRefreshToken = async (refreshToken: string): Promise<AuthTokenResponseTypes> => {
+  const response = await refreshClient.post<AuthTokenResponseTypes>('/auth/refresh', {
+    refresh_token: refreshToken,
+  });
+  return response.data;
+};
+
+const redirectToLogin = () => {
+  removeAuthTokens();
+  // 이미 로그인 페이지라면 리다이렉트하지 않는다. window.location.href는
+  // SPA 전체를 리로드시키므로, 같은 경로로 반복 대입하면 화면이 깜빡이며
+  // effect가 처음부터 다시 도는 원인이 된다.
+  if (window.location.pathname !== LOGIN_PATH) {
+    window.location.href = LOGIN_PATH;
+  }
+};
+
+let refreshPromise: Promise<string | null> | null = null;
+
+export const refreshAccessToken = (): Promise<string | null> => {
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      const refreshToken = getRefreshToken();
+      if (!refreshToken) return null;
+
+      try {
+        const { access_token, refresh_token } = await postRefreshToken(refreshToken);
+        setAuthTokens(access_token, refresh_token);
+        return access_token;
+      } catch {
+        return null;
+      }
+    })().finally(() => {
+      refreshPromise = null;
+    });
+  }
+  return refreshPromise;
+};
+
 // Request Interceptor 설정
 http.interceptors.request.use((config) => {
   // 서버에 요청 전에 localStorage에서 토큰을 가져와 헤더에 추가
@@ -24,19 +80,24 @@ http.interceptors.request.use((config) => {
 // Response Interceptor 설정 — 에러 공통 처리
 http.interceptors.response.use(
   (response) => response,
-  (error) => {
-    // 401은 토큰 만료/무효를 의미한다. 죽은 토큰을 지우지 않으면 로그인 페이지로
-    // 리로드된 뒤에도 마운트 시 실행되는 요청들이 같은 토큰으로 다시 401을 맞아
-    // 리로드→요청→401→리로드의 무한 루프에 빠진다.
-    if (error.response?.status === 401) {
-      removeAuthTokens();
-      // 이미 로그인 페이지라면 리다이렉트하지 않는다. window.location.href는
-      // SPA 전체를 리로드시키므로, 같은 경로로 반복 대입하면 화면이 깜빡이며
-      // effect가 처음부터 다시 도는 원인이 된다.
-      if (window.location.pathname !== LOGIN_PATH) {
-        window.location.href = LOGIN_PATH;
+  async (error) => {
+    const originalRequest = error.config as
+      | (InternalAxiosRequestConfig & { _retry?: boolean })
+      | undefined;
+
+    if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      const newAccessToken = await refreshAccessToken();
+      if (newAccessToken) {
+        originalRequest.headers = originalRequest.headers ?? {};
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return http(originalRequest);
       }
+
+      redirectToLogin();
     }
+
     return Promise.reject(error); // 에러를 호출한 곳으로 전달
   },
 );

--- a/src/shared/apis/axios.ts
+++ b/src/shared/apis/axios.ts
@@ -10,6 +10,10 @@ import {
 import type { AuthTokenResponseTypes } from '@/pages/login/types/loginTypes';
 import type { InternalAxiosRequestConfig } from 'axios';
 
+interface RetryableRequestConfigTypes extends InternalAxiosRequestConfig {
+  _retry?: boolean;
+}
+
 const LOGIN_PATH = '/login';
 
 const http = axios.create({
@@ -81,9 +85,7 @@ http.interceptors.request.use((config) => {
 http.interceptors.response.use(
   (response) => response,
   async (error) => {
-    const originalRequest = error.config as
-      | (InternalAxiosRequestConfig & { _retry?: boolean })
-      | undefined;
+    const originalRequest = error.config as RetryableRequestConfigTypes | undefined;
 
     if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
       originalRequest._retry = true;

--- a/src/shared/hooks/useDetectionSocket.ts
+++ b/src/shared/hooks/useDetectionSocket.ts
@@ -1,12 +1,16 @@
 import { useEffect, useRef } from 'react';
 
+import { refreshAccessToken } from '@/shared/apis/axios';
 import { getWebSocketBaseUrl } from '@/shared/utils/getWebSocketBaseUrl';
+import { isTokenExpired } from '@/shared/utils/jwt';
+import { getAccessToken } from '@/pages/login/utils/tokenStorage';
+
 import type {
   DetectionMessageTypes,
   DetectionTypes,
 } from '@/shared/types/detectionTypes';
 
-// 인증 실패 시 서버가 보내는 close code. 토큰 문제이므로 재연결하지 않는다.
+// 인증 실패 시 서버가 보내는 close code.
 // 단, 핸드셰이크가 거부되면 브라우저는 4401 대신 1006을 주기도 하므로 단독 신호로는 부족하다.
 const AUTH_FAILED_CLOSE_CODE = 4401;
 // 정상 종료(cleanup에서 우리가 의도적으로 닫을 때) 사용하는 close code.
@@ -17,6 +21,7 @@ const MAX_RECONNECT_DELAY = 30000;
 // 한 번도 연결에 성공하지 못한 채(onopen 없이) 닫히는 상황의 연속 재시도 상한.
 // 가짜/만료 토큰처럼 매번 같은 이유로 거부될 때 서버를 무한히 두드리지 않게 한다.
 const MAX_INITIAL_CONNECT_ATTEMPTS = 5;
+const MAX_AUTH_REFRESH_ATTEMPTS = 2;
 
 interface UseDetectionSocketParamsTypes {
   // 인증에 쓸 access token. 호출부(App)가 매 렌더마다 최신 값을 읽어 넘긴다.
@@ -29,12 +34,14 @@ interface UseDetectionSocketParamsTypes {
 
 // 실시간 소리 감지 알림을 받는 WebSocket을 연결하는 훅.
 // 토큰이 있을 때만 연결하고, detection 메시지를 받으면 onDetection 콜백으로 넘긴다.
-// 비정상 종료 시 지수 백오프로 재연결하되, 인증 실패(4401) 또는 연결조차 못 한
+// 비정상 종료 시 지수 백오프로 재연결하되, 연결조차 못 한
 // 반복 거부(상한 초과)는 재연결하지 않아 잘못된 토큰으로 서버를 무한히 두드리지 않는다.
 export const useDetectionSocket = ({ token, onDetection }: UseDetectionSocketParamsTypes) => {
   // 콜백이 매 렌더마다 바뀌어도 effect를 재실행하지 않도록 ref로 최신 콜백을 참조한다.
   const onDetectionRef = useRef(onDetection);
-  onDetectionRef.current = onDetection;
+  useEffect(() => {
+    onDetectionRef.current = onDetection;
+  });
 
   useEffect(() => {
     // 로그인 전(토큰 없음)에는 연결하지 않는다. 토큰이 생겨 재호출되면 그때 연결된다.
@@ -49,10 +56,27 @@ export const useDetectionSocket = ({ token, onDetection }: UseDetectionSocketPar
     let hasConnected = false;
     // onopen 없이 연속으로 닫힌 횟수. 상한을 넘으면 인증/거부로 보고 재연결을 멈춘다.
     let initialConnectAttempts = 0;
+    let authRefreshAttempts = 0;
 
-    const connect = () => {
+    const getValidToken = async (): Promise<string | null> => {
+      const storedToken = getAccessToken();
+      if (!storedToken) return null;
+      if (!isTokenExpired(storedToken)) return storedToken;
+
+      return refreshAccessToken();
+    };
+
+    const connect = async () => {
+      const validToken = await getValidToken();
+      if (isUnmounted) return;
+
+      if (!validToken) {
+        console.error('[WS] 유효한 토큰을 확보하지 못해 연결을 중단합니다. (재로그인 필요)');
+        return;
+      }
+
       // 토큰에 쿼리스트링 예약 문자(+, /, = 등)가 있어도 깨지지 않도록 인코딩한다.
-      const encodedToken = encodeURIComponent(token);
+      const encodedToken = encodeURIComponent(validToken);
       const url = `${getWebSocketBaseUrl()}/ws/users/me/detections?token=${encodedToken}`;
       socket = new WebSocket(url);
 
@@ -61,6 +85,7 @@ export const useDetectionSocket = ({ token, onDetection }: UseDetectionSocketPar
         hasConnected = true;
         reconnectDelay = INITIAL_RECONNECT_DELAY;
         initialConnectAttempts = 0;
+        authRefreshAttempts = 0;
       };
 
       socket.onmessage = (event) => {
@@ -83,12 +108,15 @@ export const useDetectionSocket = ({ token, onDetection }: UseDetectionSocketPar
       };
 
       socket.onclose = (event) => {
-        // 의도적 종료(cleanup)나 인증 실패(4401)는 재연결하지 않는다.
-        // 서버발 정상 종료(1000: 재배포/유휴 타임아웃 등)는 재연결 대상이다.
         if (isUnmounted) return;
 
         if (event.code === AUTH_FAILED_CLOSE_CODE) {
-          console.error('[WS] 인증 실패로 연결이 종료되었습니다.');
+          authRefreshAttempts += 1;
+          if (authRefreshAttempts > MAX_AUTH_REFRESH_ATTEMPTS) {
+            console.error('[WS] 인증 실패가 반복되어 재연결을 중단합니다. (재로그인 필요)');
+            return;
+          }
+          reconnectTimer = setTimeout(connect, INITIAL_RECONNECT_DELAY);
           return;
         }
 

--- a/src/shared/utils/jwt.ts
+++ b/src/shared/utils/jwt.ts
@@ -1,0 +1,26 @@
+const EXPIRY_BUFFER_MS = 5000;
+
+const decodeJwtPayload = (token: string): { exp?: number } | null => {
+  const base64Url = token.split('.')[1];
+  if (!base64Url) return null;
+
+  try {
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const json = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`)
+        .join(''),
+    );
+    return JSON.parse(json) as { exp?: number };
+  } catch {
+    return null;
+  }
+};
+
+export const isTokenExpired = (token: string): boolean => {
+  const payload = decodeJwtPayload(token);
+  if (!payload?.exp) return true;
+
+  return Date.now() >= payload.exp * 1000 - EXPIRY_BUFFER_MS;
+};

--- a/src/shared/utils/jwt.ts
+++ b/src/shared/utils/jwt.ts
@@ -1,6 +1,10 @@
+interface JwtPayloadTypes {
+  exp?: number;
+}
+
 const EXPIRY_BUFFER_MS = 5000;
 
-const decodeJwtPayload = (token: string): { exp?: number } | null => {
+const decodeJwtPayload = (token: string): JwtPayloadTypes | null => {
   const base64Url = token.split('.')[1];
   if (!base64Url) return null;
 
@@ -12,7 +16,7 @@ const decodeJwtPayload = (token: string): { exp?: number } | null => {
         .map((char) => `%${char.charCodeAt(0).toString(16).padStart(2, '0')}`)
         .join(''),
     );
-    return JSON.parse(json) as { exp?: number };
+    return JSON.parse(json) as JwtPayloadTypes;
   } catch {
     return null;
   }


### PR DESCRIPTION
<!--
제목 작성은 이렇게 해주세요!
작업 종류: 작업한 항목 #이슈번호
ex) Feature: 로그인/회원가입 구현
ex) Remove: 로그인 일부 코드 삭제
-->
<!--PR 날리고 팀원들에게 알리기 (디스코드에 @everyone이라고 적어서 알려주세요) 📢-->
ㅁ
## #️⃣ 연관된 이슈

<!-- 이슈 번호를 작성해 주세요! ex) #11-->

- close #110 

<br/>

## 💻 작업 내용

access token 수명이 60분인 것에 비해 refresh 로직이 없어서, 로그인 1시간 후부터 WebSocket이 403으로 끊기고 REST 요청도 refresh 시도 없이 바로 로그아웃되던 문제를 고쳤습니다.

변경 사항

- tokenStorage.ts: getRefreshToken 추가
- shared/utils/jwt.ts : access token 만료 여부 판단하는 isTokenExpired
- shared/apis/axios.ts: 401 시 /auth/refresh로 재발급 후 원 요청 재시도 (동시 401은 refresh 1회만 실행), refresh까지 실패해야 로그인 페이지로 이동
- shared/hooks/useDetectionSocket.ts: WebSocket 연결/재연결 전 토큰 만료 체크 → refresh 후 연결, 4401로 끊겨도 refresh 후 재연결 시도(최대 2회)

<br/>

## 📸 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

<br/>

## 🌟 리뷰 요구사항

- [ ] access token 만료 상태에서 REST 요청 시 자동 refresh + 재요청 확인
- [ ]  access token 만료 후 새로고침 없이 WebSocket이 refresh 후 재연결되는지 확인
- [ ]  refresh_token까지 만료된 경우 로그인 페이지로 정상 이동하는지 확인

<br/>

## 🔗 참고 자료

<!--관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 대화 화면에서 양방향 입력과 음성 청취를 지원합니다.
  * 대화 기록, 자주 쓰는 답변 메뉴와 대화 종료 기능을 제공합니다.
  * 대화 저장 완료 안내를 표시합니다.
  * 입력 내용에 맞춰 대화 버블 크기가 자동으로 조정됩니다.
  * 위치 정보와 대화 화면 디자인을 개선했습니다.

* **개선 사항**
  * 대화 추가 시 최신 메시지로 자동 스크롤됩니다.
  * 인증 만료 시 토큰을 자동 갱신하고 요청을 재시도합니다.
  * WebSocket 연결 시 인증 갱신 및 재연결 안정성을 강화했습니다.
  * 위치명이 “서울시 성북구”로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->